### PR TITLE
(#19162) Finish applying, then reboot

### DIFF
--- a/lib/puppet/provider/reboot/base.rb
+++ b/lib/puppet/provider/reboot/base.rb
@@ -12,7 +12,14 @@ Puppet::Type.type(:reboot).provide(:base) do
   def when=(value)
   end
 
-  def reboot
+  def apply
+    :absent
+  end
+
+  def apply=(value)
+  end
+
+  def cancel_transaction
     Puppet::Application.stop!
   end
 end

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -27,7 +27,13 @@ Puppet::Type.type(:reboot).provide :windows, :parent => :base do
   end
 
   def reboot
-    super
+    if @resource[:apply] == :finished && @resource[:when] == :pending
+      Puppet.warning("The combination of `when => pending` and `apply => finished` is not a recommended or supported scenario. Please only use this scenario if you know exactly what you are doing. The puppet agent run will continue.")
+    end
+
+    unless @resource[:apply] == :finished
+      cancel_transaction
+    end
 
     # for demo/testing
     interactive = @resource[:prompt] ? '/i' : nil

--- a/lib/puppet/provider/reboot/windows/watcher.rb
+++ b/lib/puppet/provider/reboot/windows/watcher.rb
@@ -1,13 +1,15 @@
-require 'windows/process'
-require 'windows/synchronize'
-require 'windows/handle'
-require 'windows/error'
-
 class Watcher
-  include Windows::Process
-  include Windows::Synchronize
-  include Windows::Handle
-  include Windows::Error
+
+  if File::ALT_SEPARATOR
+    require 'windows/process'
+    require 'windows/synchronize'
+    require 'windows/handle'
+    require 'windows/error'
+
+    include Windows::Process
+    include Windows::Synchronize
+    include Windows::Handle
+  end
 
   attr_reader :pid, :timeout, :command
 

--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -35,6 +35,23 @@ Puppet::Type.newtype(:reboot) do
         provider        => windows,
         require         => Reboot['before'],
       }
+
+    A reboot resource can also finish the run and then reboot the system.  For
+    example, if you have a few packages that all require reboots but will not block 
+    each other during the run.
+
+    Sample usage:
+
+      package { 'Microsoft .NET Framework 4.5':
+        ensure          => installed,
+        source          => '\\server\share\dotnetfx45_full_x86_x64.exe',
+        install_options => ['/Passive', '/NoRestart'],
+        provider        => windows,
+      }
+      reboot { 'after_run':
+        apply           => finished,
+        subscribe       => Package['Microsoft .NET Framework 4.5'],
+      }
   EOT
 
   feature :manages_reboot_pending, "The provider can detect if a reboot is pending, and reboot as needed."
@@ -57,6 +74,26 @@ Puppet::Type.newtype(:reboot) do
     def insync?(is)
       case should
       when :refreshed
+        true # we're always insync
+      else
+        super
+      end
+    end
+  end
+
+  newproperty(:apply) do
+    desc "When to apply the reboot. If `immediately`, then the provider
+      will stop applying additional resources and apply the reboot once
+      puppet has finished syncing. If `finished`, it will continue
+      applying resources and then perform a reboot at the end of the
+      run. The default is `immediately`."
+    newvalue(:immediately)
+    newvalue(:finished)
+    defaultto :immediately
+
+    def insync?(is)
+      case should
+      when :immediately
         true # we're always insync
       else
         super
@@ -103,7 +140,8 @@ Puppet::Type.newtype(:reboot) do
   newparam(:timeout) do
     desc "The amount of time in seconds to wait between the time the reboot
       is requested and when the reboot is performed.  The default timeout
-      is 60 seconds."
+      is 60 seconds.  Note that this time starts once puppet has exited the
+      current run."
 
     validate do |value|
       begin

--- a/spec/unit/provider/reboot/base_spec.rb
+++ b/spec/unit/provider/reboot/base_spec.rb
@@ -18,12 +18,4 @@ describe Puppet::Type.type(:reboot).provider(:base) do
       provider.when = :refreshed
     end
   end
-
-  context "when a reboot is triggered" do
-    it "should request that the application stop" do
-      Puppet::Application.expects(:stop!)
-
-      provider.reboot
-    end
-  end
 end

--- a/spec/unit/provider/reboot/windows/watcher_spec.rb
+++ b/spec/unit/provider/reboot/windows/watcher_spec.rb
@@ -1,8 +1,10 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
-require 'puppet/provider/reboot/windows/watcher.rb'
 
-describe Watcher, :if => Puppet.features.microsoft_windows? do
+describe 'Watcher', :if => Puppet.features.microsoft_windows? do
+
+  require 'puppet/provider/reboot/windows/watcher.rb'
+
   let(:current_pid) { Process.pid }
   let(:bogus_pid) { 0xFFFFFFFF }
   let(:timeout) { 1 }

--- a/spec/unit/type/reboot_spec.rb
+++ b/spec/unit/type/reboot_spec.rb
@@ -50,6 +50,22 @@ describe Puppet::Type.type(:reboot) do
     end
   end
 
+  context "parameter :apply" do
+    it "should default to :immediately" do
+      resource[:apply].must == :immediately
+    end
+
+    it "should accept :finished" do
+      resource[:apply] = :finished
+    end
+
+    it "should reject other values" do
+      expect {
+        resource[:apply] = :whenever
+      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are immediately/)
+    end
+  end
+
   context "parameter :message" do
     it "should default to \"Puppet is rebooting the computer\"" do
       resource[:message].must == "Puppet is rebooting the computer"


### PR DESCRIPTION
Added apply with two options: immediately (default) and finished. When
`apply => finished`, it allows puppet to finish applying resources and then
reboot the computer at the end of the catalog run.

When someone selects `apply => finished` and `when => pending`, the behavior
will be allowed but will warn that this is an unsupported scenario. I don't
always understand the needs of the users so I didn't want to constrain this
option. If a sufficiently advanced user knows exactly what they are doing and
wants to set this behavior, it should be allowed.
