### PR TITLE
(#22712) Module Path Spaces Fix

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:reboot).provide :windows, :parent => :base do
     end
 
     Puppet.debug("Launching 'ruby.exe #{watcher}'")
-    stdin, wait_threads = Open3.pipeline_w("ruby.exe #{watcher}")
+    stdin, wait_threads = Open3.pipeline_w("ruby.exe '#{watcher}'")
     Process.detach(wait_threads[0].pid)
 
     # order is important


### PR DESCRIPTION
This allows for spaces in the path to the module, which you see in Windows 2003
as it has a default path to the modules that has multiple spaces in it.
