### PR TITLE
(#9) Fix Reboot Description in Init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,39 +1,120 @@
 # == Class: reboot
 #
-# Full description of class reboot here.
+# This module provides a type and provider for managing systems reboots.
+# Currently, only Windows is supported.
+#
+# The module supports two forms of reboots. The first form occurs when
+# puppet installs a package, and a reboot is required to complete
+# installation. This is the default mode of operation, as it ensures
+# puppet will only reboot the system in response to another resource being
+# applied, such as a package install.
+#
+# The second form is where a reboot is pending, and puppet needs to
+# reboot the system before applying any other resources. For example,
+# some Windows packages cannot be installed while a reboot is pending.
+# The second form is specified via when => pending.
 #
 # === Parameters
 #
-# Document parameters here.
+# [*name*]
+#   The name of the reboot resource. Used for uniqueness.
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# [*apply*]
+#   When to apply the reboot. If immediately, then the provider will
+#   stop applying additional resources and apply the reboot once puppet
+#   has finished syncing. If finished, it will continue applying
+#   resources and then perform a reboot at the end of the run. The
+#   default is immediately. Valid values are immediately, finished.
+#
+# [*message*]
+#   The message to log when the reboot is performed.
+#
+# [*prompt*]
+#   Whether to prompt the user to continue the reboot. By default, the
+#   user will not be prompted. Valid values are true, false.
+#
+# [*catalog_apply_timeout*]
+#   The maximum amount of time in seconds to wait for puppet to finish
+#   applying the catalog. If puppet is still running when the timeout is
+#   reached, the reboot will not be requested. The default value is
+#   7200 seconds (2 hours).
+#
+# [*timeout*]
+#   The amount of time in seconds to wait between the time the reboot is
+#   requested and when the reboot is performed. The default timeout is
+#   60 seconds. Note that this time starts once puppet has exited the
+#   current run.
+#
+# === Properties
+#
+# [*when*]
+#   When to check for, and if needed, perform a reboot. If pending,
+#   then the provider will check if a reboot is pending, and only if
+#   needed, reboot the system. If refreshed then the reboot will only
+#   be performed in response to a refresh event from another resource,
+#   e.g. package. Valid values are refreshed, pending.
 #
 # === Variables
 #
-# Here you should define a list of variables that this module would require.
-#
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if it
-#   has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should not be used in preference to class parameters  as of
-#   Puppet 2.6.)
 #
 # === Examples
 #
-#  class { reboot:
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ]
-#  }
+# To install .NET 4.5 and reboot, but only if the package needed to be
+# installed:
+#
+#    package { 'Microsoft .NET Framework 4.5':
+#      ensure          => installed,
+#      source          => '\\server\share\dotnetfx45_full_x86_x64.exe',
+#      install_options => ['/Passive', '/NoRestart'],
+#      provider        => windows,
+#    }
+#    reboot { 'after':
+#      subscribe       => Package['Microsoft .NET Framework 4.5'],
+#    }
+#
+# To check if a reboot is pending, and if so, reboot the system before
+# installing .NET 4.5:
+#
+#    reboot { 'before':
+#      when            => pending,
+#    }
+#    package { 'Microsoft .NET Framework 4.5':
+#      ensure          => installed,
+#      source          => '\\server\share\dotnetfx45_full_x86_x64.exe',
+#      install_options => ['/Passive', '/NoRestart'],
+#      provider        => windows,
+#      require         => Reboot['before'],
+#    }
+#
+# By default, when the provider triggers a reboot, it will skip any
+# resources in the catalog that have not yet been applied. Alternatively,
+# you can allow puppet to continue applying the entire catalog by
+# specifying apply => finished. For example, if you have several
+# packages that all require reboots, but will not block each other:
+#
+#    package { 'Microsoft .NET Framework 4.5':
+#      ensure => installed,
+#      ...
+#      notify => Reboot['after_run'],
+#    }
+#    package { 'Microsoft Windows SDK for Windows 7 (7.0)':
+#      ensure => installed,
+#      ...
+#      notify => Reboot['after_run'],
+#    }
+#    reboot { 'after_run':
+#      apply  => finished,
+#    }
 #
 # === Authors
 #
-# Author Name <author@domain.com>
+# Josh Cooper <josh@puppetlabs.com>
+# Rob Reynolds <rob@puppetlabs.com>
+# Ethan Brown <ethan@puppetlabs.com>
 #
 # === Copyright
 #
-# Copyright 2013 Your name here, unless otherwise noted.
+# Copyright 2013 Puppet Labs, unless otherwise noted.
 #
 class reboot {
 


### PR DESCRIPTION
This adds the relevant informations for anything using init.pp as a way of
gathering module information.
