### PR TITLE
(Maint) Deprecate the `prompt` parameter

### DIFF
--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -106,6 +106,14 @@ Puppet::Type.newtype(:reboot) do
   newparam(:prompt, :boolean => true) do
     desc "Whether to prompt the user to continue the reboot.  By default, the
       user will not be prompted."
+
+    munge do |value|
+      if value
+        Puppet.deprecation_warning("The `prompt` parameter is deprecated; use `shutdown /a` instead.")
+      end
+      value
+    end
+
     newvalues(:true, :false)
     defaultto(false)
   end

--- a/spec/unit/type/reboot_spec.rb
+++ b/spec/unit/type/reboot_spec.rb
@@ -96,6 +96,12 @@ describe Puppet::Type.type(:reboot) do
         resource[:prompt] = "I'm not sure"
       }.to raise_error(Puppet::ResourceError, /Invalid value "I'm not sure"/)
     end
+
+    it "should be deprecated" do
+      Puppet.expects(:deprecation_warning).with('The `prompt` parameter is deprecated; use `shutdown /a` instead.')
+
+      resource[:prompt] = true
+    end
   end
 
   context "parameter :catalog_apply_timeout" do


### PR DESCRIPTION
The `prompt` parameter was intended to allow a reboot to be canceled
when running puppet interactively, e.g. for testing, demo, etc. However,
if you are running `puppet agent`, and prompt is true, the system will
display a dialog box on the hidden service desktop (since services are no
longer allowed to interact with the desktop). This will cause the agent to
hang waiting for user input that never arrives.

This commit causes puppet to issue a deprecation warning when prompt is
set to true. The behavior when prompt is unspecified or set to false is
unchanged.

Instead of relying on the prompt parameter to cancel a shutdown, issue
the command:

```
shutdown /a
```
