### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-##2014-03-04, Supported Release
+##2014-03-04, Supported Release 0.1.5
 ###Summary
-
-####Features
-
-####Bugfixes
+This is a supported release.
 
 ####Known Bugs
 
-* No known issues.
+* The version is `0.x` but should be considered a `1.x` for semantic versioning purposes.
 
 ---
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-reboot'
-version '0.1.4'
+version '0.1.5'
 source 'git://github.com/puppetlabs/puppetlabs-reboot.git'
 author 'puppetlabs'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
### Summary

This is a supported release.
#### Known Bugs
- The version is `0.x` but should be considered a `1.x` for semantic versioning purposes.
