### PR TITLE
Declare all our testing deps in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git:[^#]*)#(.*)/
@@ -21,6 +21,7 @@ group :development, :test do
   gem 'rspec-puppet'
   gem 'mocha', "~> 0.10.5"
   gem 'puppetlabs_spec_helper'
+  gem 'beaker'
 end
 
 # see http://projects.puppetlabs.com/issues/21698


### PR DESCRIPTION
Prior to this we were running beaker from source in the test directory. Since this project was setup beaker has been released as a gem and should be added to the Gemfile. Doing so makes the project's testing much less brittle.
