### PR TITLE
Fix windows != to windows error on Windows2008

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:reboot).provide :windows do
   end
 
   def reboot
-    if Facter[:operatingsystem] != 'windows'
+    if Facter[:operatingsystem].value != 'windows'
       raise Puppet::Error, "Unsupported OS #{Facter.operatingsystem} for Windows Provider"
     end
 


### PR DESCRIPTION
Resolves PE 3.2.3 and Facter 1.7.5 on Windows 2008R2 error:

```
==> default: Error: /Stage[main]/Main/Reboot[after]: Failed to call
refresh: Unsupported OS windows for Windows Provider
==> default:
==> default: Error: /Stage[main]/Main/Reboot[after]: Unsupported OS
windows for Windows Provider
```
