### PR TITLE
(MODULES-1729) Round :timeout up to the nearest minute and warn

### DIFF
--- a/lib/puppet/provider/reboot/linux.rb
+++ b/lib/puppet/provider/reboot/linux.rb
@@ -35,7 +35,10 @@ Puppet::Type.type(:reboot).provide :linux do
     end
 
     seconds = @resource[:timeout].to_i
-    minutes = seconds / 60
+    minutes = (seconds / 60.0).ceil
+    if seconds % 60 != 0
+      Puppet.warning("Shutdown command on this system specifies time in minutes, rounding #{seconds} seconds up to #{minutes} minutes.")
+    end
 
     shutdown_cmd = [shutdown_path, '-r', "+#{minutes}", %Q("#{@resource[:message]}"), '</dev/null', '>/dev/null', '2>&1', '&'].join(' ')
     async_shutdown(shutdown_cmd)

--- a/spec/unit/provider/reboot/linux_spec.rb
+++ b/spec/unit/provider/reboot/linux_spec.rb
@@ -57,7 +57,14 @@ describe Puppet::Type.type(:reboot).provider(:linux) do
     end
 
     it "includes a timeout in the future" do
-      provider.expects(:async_shutdown).with(includes("+#{resource[:timeout].to_i / 60}"))
+      provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
+      provider.reboot
+    end
+
+    it "rounds up and provides a warning if the timeout is not a multiple of 60" do
+      resource[:timeout] = 61
+      Puppet.expects(:warning).with(includes('rounding'))
+      provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
       provider.reboot
     end
 


### PR DESCRIPTION
Linux uses minutes to specify its shutdown timeout, but the :timeout parameter is in seconds. Ruby uses integer division, so previously values of `:timeout` that weren't whole multiples of 60 would be rounded down. This changes the behavior so that they are rounded up and a warning is issued notifying the user.