### PR TITLE
(MODULES-1730) Only run the shutdown command once

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -34,7 +34,12 @@ Puppet::Type.type(:reboot).provide :windows do
 
   def when=(value)
     if @resource[:when] == :pending
-      reboot
+      if @resource.class.rebooting
+        Puppet.debug("Reboot already scheduled; skipping")
+      else
+        @resource.class.rebooting = true
+        reboot
+      end
     end
   end
 

--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -147,10 +147,25 @@ Puppet::Type.newtype(:reboot) do
     defaultto 60
   end
 
+  @rebooting = false
+
+  def self.rebooting
+    @rebooting
+  end
+
+  def self.rebooting=(value)
+    @rebooting = value
+  end
+
   def refresh
     case self[:when]
     when :refreshed
-      provider.reboot
+      if self.class.rebooting
+        Puppet.debug("Reboot already scheduled; skipping")
+      else
+        self.class.rebooting = true
+        provider.reboot
+      end
     else
       Puppet.debug("Skipping reboot")
     end

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -9,6 +9,10 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
   let(:native_path)     { "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe" }
   let(:redirected_path) { "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe" }
 
+  before :each do
+    resource.class.rebooting = false
+  end
+
   it "should be an instance of Puppet::Type::Reboot::ProviderWindows" do
     provider.must be_an_instance_of Puppet::Type::Reboot::ProviderWindows
   end
@@ -129,6 +133,46 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
       resource[:message] = "triggering a reboot"
       provider.expects(:async_shutdown).with(includes('"triggering a reboot"'))
       provider.reboot
+    end
+
+    context "multiple triggered reboots" do
+      let(:resource2) { Puppet::Type.type(:reboot).new(:provider => :windows, :name => "windows_reboot2") }
+      let(:provider2) { resource2.provider }
+
+      context "where the second resource has when set to pending" do
+        before :each do
+          resource2[:when] = :pending
+        end
+
+        context "where the first resource has apply set to finished" do
+          before :each do
+            resource[:apply] = :finished
+          end
+
+          it "should only reboot once" do
+            resource[:when] = :refreshed
+            provider.expects(:reboot)
+
+            resource.refresh
+
+            provider2.expects(:reboot).never
+            Puppet.expects(:debug).with(includes('already scheduled'))
+            provider2[:when] = :pending
+          end
+
+          it "should only reboot once when the first resource has when set to pending" do
+            # this isn't supported but no harm testing that it doesn't blow up
+            resource[:when] = :pending
+            provider.expects(:reboot)
+            Puppet.expects(:warning).with(includes('The combination'))
+            provider[:when] = :pending
+
+            provider2.expects(:reboot).never
+            Puppet.expects(:debug).with(includes('already scheduled'))
+            provider2[:when] = :pending
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
As per [MODULES-1730](https://tickets.puppetlabs.com/browse/MODULES-1730), if multiple reboot resources attempt to schedule a reboot, the system's shutdown command is executed multiple times.  If it doesn't check for this, unexpected behavior can result.  This adds a check that the shutdown command is only scheduled once by the reboot type.