### PR TITLE
Travis improvements: run on non-master branches, build on Ruby 1.8.7, and reduce build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without development system_tests
 script: bundle exec rake spec SPEC_OPTS='--format documentation'
 rvm:
   - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 ---
-branches:
-  only:
-    - master
 language: ruby
 bundler_args: --without development
 script: bundle exec rake spec SPEC_OPTS='--format documentation'

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,6 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
 
 is_ruby18 = RUBY_VERSION.start_with? '1.8'
 
-beaker_version = ENV['BEAKER_VERSION']
-beaker_version = "~> 1.20" if is_ruby18
 group :development, :test do
   if is_ruby18
     gem 'pry', "~> 0.9.12"
@@ -32,6 +30,10 @@ group :development, :test do
   gem 'mime-types', '<2.0',      :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false
+end
+
+beaker_version = ENV['BEAKER_VERSION']
+group :system_tests do
   if beaker_version
     gem 'beaker', *location_for(beaker_version)
   else


### PR DESCRIPTION
Allowing Travis to run on other branches can simplify development by catching test failures before a pull request is made.