### PR TITLE
Fix reboot spec tests

### DIFF
--- a/acceptance/setup/install_modules.rb
+++ b/acceptance/setup/install_modules.rb
@@ -1,15 +1,15 @@
 test_name 'Install modules' do
+
   hosts.each do |host|
+    on host, "mkdir -p #{host['distmoduledir']}"
     if host['platform'] =~ /windows/
-      on host, "mkdir -p #{host['distmoduledir']}/reboot"
-      on host, "cd #{host['distmoduledir']} && git clone --branch 1.0.x --depth 1 git://github.com/puppetlabs/puppetlabs-registry.git registry"
-      on host, "cd #{host['distmoduledir']} && git clone --branch 4.3.2 --depth 1 git://github.com/puppetlabs/puppetlabs-stdlib.git stdlib"
+      on host, "cd #{host['distmoduledir']} && git clone --branch 1.1.x --depth 1 git://github.com/puppetlabs/puppetlabs-registry.git registry"
+      on host, "cd #{host['distmoduledir']} && git clone --branch 4.6.x --depth 1 git://github.com/puppetlabs/puppetlabs-stdlib.git stdlib"
     else
-      on host, "mkdir -p #{host['distmoduledir']}/reboot"
+      on host, 'rm -rf /etc/puppetlabs/puppet/environments/production/modules/reboot'
       on host, puppet('module install puppetlabs/stdlib')
       on host, puppet('module install puppetlabs/registry')
-
     end
-    install_dev_puppet_module_on(host, {:module_name => 'reboot'})
+    copy_root_module_to(host, :module_name => 'reboot')
   end
 end


### PR DESCRIPTION
Ensure module is removed from linux nodes before installing
Change to copy_root_module_to as the other does not work on windows systems due to CA issues