### PR TITLE
(MODULES-1724) Emit notice when scheduling reboot

### DIFF
--- a/acceptance/tests/posix/reboot_message.rb
+++ b/acceptance/tests/posix/reboot_message.rb
@@ -26,6 +26,8 @@ posix_agents.each do |agent|
     end
     assert_match expected_command,
       result.stdout, 'Expected reboot message is incorrect'
+    assert_match /Scheduling system reboot with message: \"A different message\"/,
+      result.stdout, 'Reboot message was not logged'
   end
 
   #Verify that a shutdown has been initiated and clear the pending shutdown.

--- a/acceptance/tests/windows/reboot_message.rb
+++ b/acceptance/tests/windows/reboot_message.rb
@@ -20,6 +20,8 @@ windows_agents.each do |agent|
   on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
     assert_match /shutdown\.exe \/r \/t 60 \/d p:4:1 \/c \"A different message\"/,
       result.stdout, 'Expected reboot message is incorrect'
+    assert_match /Scheduling system reboot with message: \"A different message\"/,
+      result.stdout, 'Reboot message was not logged'
   end
 
   #Verify that a shutdown has been initiated and clear the pending shutdown.

--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -141,6 +141,7 @@ Puppet::Type.newtype(:reboot) do
         Puppet.debug("Reboot already scheduled; skipping")
       else
         self.class.rebooting = true
+        Puppet.notice("Scheduling system reboot with message: \"#{self[:message]}\"")
         provider.reboot
       end
     else

--- a/spec/unit/type/reboot_spec.rb
+++ b/spec/unit/type/reboot_spec.rb
@@ -91,6 +91,14 @@ describe Puppet::Type.type(:reboot) do
         resource[:message] = 'a' * 8001
       }.to raise_error(Puppet::ResourceError, /The given message must not exceed 8000 characters./)
     end
+
+    it "should be logged on reboot" do
+      resource[:message] = "Custom message"
+      logmessage = "Scheduling system reboot with message: \"Custom message\""
+      Puppet.expects(:notice).with(logmessage)
+      resource.provider.expects(:reboot)
+      resource.refresh
+    end
   end
 
   context "parameter :timeout" do


### PR DESCRIPTION
As requested in [MODULES-1724](https://tickets.puppetlabs.com/browse/MODULES-1724), this will allow external processes to identify if a reboot was initiated by Puppet.