### PR TITLE
(MODULES-1977) Fix problems with POSIX provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The main type of the module, responsible for all its functionality.
 ####Providers
 
 * `windows`: Default for :kernel => :windows
+* `linux`: Deprecated. Use `posix` instead.
 * `posix`: Default for :feature => :posix
 
 ####Features

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -69,6 +69,10 @@ module Puppet
       def posix_agents
         agents.select { |agent| !agent['platform'].include?('windows') }
       end
+
+      def linux_agents
+        agents.select { |agent| fact_on(agent, 'kernel') == 'Linux' }
+      end
     end
   end
 end

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -37,7 +37,11 @@ module Puppet
         if windows_agents.include?(agent)
           on(agent, WINDOWS_SHUTDOWN_ABORT, :acceptable_exit_codes => [WINDOWS_SHUTDOWN_NOT_IN_PROGRESS])
         else
-          on(agent, POSIX_SHUTDOWN_ABORT, :acceptable_exit_codes => [POSIX_SHUTDOWN_NOT_IN_PROGRESS])
+          pid = shutdown_pid(agent)
+          if pid
+            on(agent, "kill #{pid}", :acceptable_exit_codes => [0])
+            raise CommandFailure, "Host '#{agent}' had unexpected scheduled shutdown with PID #{pid}."
+          end
         end
       end
 
@@ -48,7 +52,7 @@ module Puppet
             result = on(agent, WINDOWS_SHUTDOWN_ABORT, :acceptable_exit_codes => [0, WINDOWS_SHUTDOWN_NOT_IN_PROGRESS])
           else
             pid = shutdown_pid(agent)
-            result = on(agent, "kill #{pid}") if pid
+            result = on(agent, "kill #{pid}", :acceptable_exit_codes => [0]) if pid
           end
           break if result.exit_code == 0
 

--- a/acceptance/tests/linux/reboot_finished.rb
+++ b/acceptance/tests/linux/reboot_finished.rb
@@ -1,0 +1,30 @@
+test_name "Reboot Module - Linux Provider - Reboot when Finished"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+} ~>
+reboot { 'now':
+  apply => finished,
+  provider => linux,
+} ->
+notify { 'step_2':
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot After Finishing Complete Catalog"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /defined 'message' as 'step_2'/,
+      result.stdout, 'Expected step was not finished before reboot'
+  end
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_immediate.rb
+++ b/acceptance/tests/linux/reboot_immediate.rb
@@ -1,0 +1,25 @@
+test_name "Reboot Module - Linux Provider - Reboot Immediately"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+}
+~>
+reboot { 'now':
+  provider => linux,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot Immediately with Refresh"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_immediate_explicit.rb
+++ b/acceptance/tests/linux/reboot_immediate_explicit.rb
@@ -1,0 +1,26 @@
+test_name "Reboot Module - Linux Provider - Reboot Immediately Explicit"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+}
+~>
+reboot { 'now':
+  apply => immediately,
+  provider => linux,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot Immediately (Explicit) with Refresh"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_message.rb
+++ b/acceptance/tests/linux/reboot_message.rb
@@ -1,0 +1,32 @@
+test_name "Reboot Module - Linux Provider - Custom Message"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+}
+~>
+reboot { 'now':
+  when => refreshed,
+  message => 'A different message',
+  provider => linux,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot Immediately with a Custom Message"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /shutdown -r \+1 \"A different message\"/,
+      result.stdout, 'Expected reboot message is incorrect'
+    assert_match /Scheduling system reboot with message: \"A different message\"/,
+      result.stdout, 'Reboot message was not logged'
+  end
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_no_refresh.rb
+++ b/acceptance/tests/linux/reboot_no_refresh.rb
@@ -1,0 +1,23 @@
+test_name "Reboot Module - Linux Provider - No Refresh"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+reboot { 'now':
+  provider => linux
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Attempt to Reboot Computer without Refresh"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest
+
+  #Verify that a shutdown has NOT been initiated because reboot
+  #was not refreshed.
+  ensure_shutdown_not_scheduled(agent)
+end

--- a/acceptance/tests/linux/reboot_refreshed_explicit.rb
+++ b/acceptance/tests/linux/reboot_refreshed_explicit.rb
@@ -1,0 +1,26 @@
+test_name "Reboot Module - Linux Provider - Reboot when Refreshed Explicit"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+}
+~>
+reboot { 'now':
+  when => refreshed,
+  provider => linux,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot when Refreshed (Explicit)"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_resume.rb
+++ b/acceptance/tests/linux/reboot_resume.rb
@@ -1,0 +1,61 @@
+test_name "Reboot Module - Linux Provider - Puppet Resume after Reboot"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+file { '/first.txt':
+  ensure => file,
+} ~>
+reboot { 'first_reboot':
+  provider => linux,
+} ->
+file { '/second.txt':
+  ensure => file,
+} ~>
+reboot { 'second_reboot':
+  provider => linux,
+}
+MANIFEST
+
+remove_artifacts = <<-MANIFEST
+file { '/first.txt':
+  ensure => absent,
+}
+file { '/second.txt':
+  ensure => absent,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+teardown do
+  step "Remove Test Artifacts"
+  on agents, puppet('apply', '--debug'), :stdin => remove_artifacts
+end
+
+linux_agents.each do |agent|
+  step "Attempt First Reboot"
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /\[\/first.txt\]\/ensure: created/,
+      result.stdout, 'Expected file was not created'
+  end
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+
+  step "Resume After Reboot"
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /\[\/second.txt\]\/ensure: created/,
+      result.stdout, 'Expected file was not created'
+  end
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+
+  step "Verify Manifest is Finished"
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest
+
+  #Verify that a shutdown has NOT been initiated.
+  ensure_shutdown_not_scheduled(agent)
+end

--- a/acceptance/tests/linux/reboot_skip.rb
+++ b/acceptance/tests/linux/reboot_skip.rb
@@ -1,0 +1,29 @@
+test_name "Reboot Module - Linux Provider - Reboot Skip"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+} ~>
+reboot { 'now':
+  provider => linux,
+} ->
+notify { 'step_2':
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot Immediately with Skipping Other Resources"
+
+  #Apply the manifest. Verify that the "step_2" notify is skipped.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /Transaction canceled, skipping/,
+      result.stdout, 'Expected resource was not skipped'
+  end
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/linux/reboot_timeout.rb
+++ b/acceptance/tests/linux/reboot_timeout.rb
@@ -1,0 +1,33 @@
+test_name "Reboot Module - Linux Provider - Custom Timeout"
+extend Puppet::Acceptance::Reboot
+
+reboot_manifest = <<-MANIFEST
+notify { 'step_1':
+}
+~>
+reboot { 'now':
+  when => refreshed,
+  timeout => 120,
+  provider => linux,
+}
+MANIFEST
+
+confine :except, :platform => 'windows' do |agent|
+  fact_on(agent, 'kernel') == 'Linux'
+end
+
+linux_agents.each do |agent|
+  step "Reboot Immediately with a Custom Timeout"
+
+  #Apply the manifest.
+  on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
+    assert_match /shutdown -r \+2/,
+      result.stdout, 'Expected reboot timeout is incorrect'
+  end
+
+  #Waiting 61 seconds guarantees that the default timeout is different.
+  sleep 61
+
+  #Verify that a shutdown has been initiated and clear the pending shutdown.
+  retry_shutdown_abort(agent)
+end

--- a/acceptance/tests/posix/reboot_timeout.rb
+++ b/acceptance/tests/posix/reboot_timeout.rb
@@ -11,15 +11,20 @@ reboot { 'now':
 }
 MANIFEST
 
-#Solaris specifies reboot timeout in seconds
-confine :except, :platform => ['windows', 'solaris']
+confine :except, :platform => 'windows'
 
 posix_agents.each do |agent|
   step "Reboot Immediately with a Custom Timeout"
 
   #Apply the manifest.
   on agent, puppet('apply', '--debug'), :stdin => reboot_manifest do |result|
-    assert_match /shutdown -r \+2/,
+    case fact('kernel')
+    when 'SunOS'
+      expected_command = /shutdown -y -i 6 -g 120/
+    else
+      expected_command = /shutdown -r \+2/
+    end
+    assert_match expected_command,
       result.stdout, 'Expected reboot timeout is incorrect'
   end
 

--- a/lib/puppet/provider/reboot/linux.rb
+++ b/lib/puppet/provider/reboot/linux.rb
@@ -1,0 +1,8 @@
+Puppet::Type.type(:reboot).provide :linux, :parent => :posix do
+  confine :kernel => :linux
+
+  def initialize(resource = nil)
+    Puppet.deprecation_warning "The 'linux' reboot provider is deprecated and will be removed; use 'posix' instead."
+    super(resource)
+  end
+end

--- a/spec/unit/provider/reboot/linux_spec.rb
+++ b/spec/unit/provider/reboot/linux_spec.rb
@@ -1,0 +1,94 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/provider/reboot/linux'
+require 'puppet/provider/reboot/posix'
+
+describe Puppet::Type.type(:reboot).provider(:linux) do
+  let(:resource) { Puppet::Type.type(:reboot).new(:provider => :linux, :name => "linux_reboot") }
+  let(:provider) { resource.provider }
+
+  it "should be an instance of Puppet::Type::Reboot::ProviderLinux" do
+    provider.must be_an_instance_of Puppet::Type::Reboot::ProviderLinux
+  end
+
+  it "should be a kind of Puppet::Type::Reboot::ProviderPosix" do
+    provider.must be_a_kind_of Puppet::Type::Reboot::ProviderPosix
+  end
+
+  context '#initialize' do
+    it 'should issue a deprecation warning' do
+      Puppet.expects(:deprecation_warning).with("The 'linux' reboot provider is deprecated and will be removed; use 'posix' instead.")
+
+      Puppet::Type.type(:reboot).new(:provider => :linux, :name => "linux_reboot")
+    end
+  end
+
+  context "self.instances" do
+    it "should return an empty array" do
+      provider.class.instances.should == []
+    end
+  end
+
+  context "when checking if the `when` property is insync" do
+    it "is absent by default" do
+      expect(provider.when).to eq(:absent)
+    end
+
+    it "should not reboot when setting the `when` property to refreshed" do
+      provider.expects(:reboot).never
+
+      provider.when = :refreshed
+    end
+  end
+
+  context "when a reboot is triggered", :if => Puppet::Util.which('shutdown') do
+    before :each do
+      provider.expects(:async_shutdown).with(includes('shutdown')).at_most_once
+    end
+
+    it "stops the application by default" do
+      Puppet::Application.expects(:stop!)
+      provider.reboot
+    end
+
+    it "cancels the rest of the catalog transaction if apply is set to immediately" do
+      resource[:apply] = :immediately
+      Puppet::Application.expects(:stop!)
+      provider.reboot
+    end
+
+    it "doesn't stop the rest of the catalog transaction if apply is set to finished" do
+      resource[:apply] = :finished
+      Puppet::Application.expects(:stop!).never
+      provider.reboot
+    end
+
+    before :each do
+      Facter.stubs(:value).with(:kernel).returns('Linux')
+    end
+
+    it "includes the restart flag" do
+      provider.expects(:async_shutdown).with(includes('-r'))
+      provider.reboot
+    end
+
+    it "includes a timeout in the future" do
+      provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
+      provider.reboot
+    end
+
+    it "rounds up and provides a warning if the timeout is not a multiple of 60" do
+      resource[:timeout] = 61
+      Puppet.expects(:warning).with(includes('rounding'))
+      provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
+      provider.reboot
+    end
+
+    it "includes the quoted reboot message" do
+      resource[:message] = "triggering a reboot"
+      provider.expects(:async_shutdown).with(includes('"triggering a reboot"'))
+      provider.reboot
+    end
+  end
+end


### PR DESCRIPTION
This adds a deprecated `linux` provider stub and enables one of the acceptance tests for Solaris that was disabled for, as it turns out, no good reason.