### PR TITLE
(MODULES-2207) Gem restrictions for Older puppet versions

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,7 +10,7 @@ Gemfile:
     ':development':
       - gem: rake
       - gem: rspec
-        version: '~>2.14.0'
+        version: '~>2.14.1'
       - gem: puppet-lint
       - gem: puppetlabs_spec_helper
       - gem: puppet_facts

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,7 +23,6 @@ Gemfile:
         version: '<2.0'
     ':system_tests':
       - gem: beaker
-      - gem: beaker-rspec
       - gem: beaker-puppet_install_helper
 Rakefile:
   unmanaged: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,6 +23,7 @@ Gemfile:
         version: '<2.0'
     ':system_tests':
       - gem: beaker
+      - gem: beaker-rspec
       - gem: beaker-puppet_install_helper
 Rakefile:
   unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :development do
   gem 'rake',                    :require => false
-  gem 'rspec', '~>2.14.0',       :require => false
+  gem 'rspec', '~>2.14.1',       :require => false
   gem 'puppet-lint',             :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet_facts',            :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -70,22 +70,39 @@ if puppet_gem_location != :gem || puppetversion < '3.5.0'
 end
 
 if explicitly_require_windows_gems
-  gem "ffi", "~> 1.9.0", :require => false
-  gem "win32-dir", "~> 0.3", :require => false
-  gem "win32-eventlog", "~> 0.5", :require => false
-  gem "win32-process", "~> 0.6", :require => false
-  gem "win32-security", "~> 0.1", :require => false
-  gem "win32-service", "~> 0.7", :require => false
-  gem "minitar", "~> 0.5.4", :require => false
-  gem "win32console", :require => false if RUBY_VERSION =~ /^1\./
+  # This also means Puppet Gem less than 3.5.0 - this has been tested back
+  # to 3.0.0. Any further back is likely not supported.
+  if puppet_gem_location == :gem
+    gem "ffi", "1.9.0",               :require => false
+    gem "win32-eventlog", "0.5.3",    :require => false
+    gem "win32-process", "0.6.5",     :require => false
+    gem "win32-security", "~> 0.1.2", :require => false
+    gem "win32-service", "0.7.2",     :require => false
+    gem "minitar", "0.5.4",           :require => false
+  else
+    gem "ffi", "~> 1.9.0",            :require => false
+    gem "win32-eventlog", "~> 0.5",   :require => false
+    gem "win32-process", "~> 0.6",    :require => false
+    gem "win32-security", "~> 0.1",   :require => false
+    gem "win32-service", "~> 0.7",    :require => false
+    gem "minitar", "~> 0.5.4",        :require => false
+  end
+
+  gem "win32-dir", "~> 0.3",          :require => false
+  gem "win32console", "1.3.2",        :require => false if RUBY_VERSION =~ /^1\./
 
   # Puppet less than 3.7.0 requires these.
   # Puppet 3.5.0+ will control the actual requirements.
-  gem "sys-admin", "~> 1.5", :require => false
-  gem "win32-api", "~> 1.4.8", :require => false
-  gem "win32-taskscheduler", "~> 0.2", :require => false
-  gem "windows-api", "~> 0.4", :require => false
-  gem "windows-pr", "~> 1.2", :require => false
+  # These are listed in formats that work with all versions of
+  # Puppet from 3.0.0 to 3.6.x. After that, these were no longer used.
+  # We do not want to allow newer versions than what came out after
+  # 3.6.x to be used as they constitute some risk in breaking older
+  # functionality. So we set these to exact versions.
+  gem "sys-admin", "1.5.6",           :require => false
+  gem "win32-api", "1.4.8",           :require => false
+  gem "win32-taskscheduler", "0.2.2", :require => false
+  gem "windows-api", "0.4.3",         :require => false
+  gem "windows-pr",  "1.2.3",         :require => false
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/Gemfile
+++ b/Gemfile
@@ -35,13 +35,9 @@ group :development do
   gem 'nokogiri', '~>1.5.10',    :require => false, :platforms => :ruby
   gem 'mime-types', '<2.0',      :require => false
 end
+
 group :system_tests do
-  beaker_version = ENV['BEAKER_VERSION'] || '~> 2.2'
-  if beaker_version
-    gem 'beaker', *location_for(beaker_version)
-  else
-    gem 'beaker', :require => false, :platforms => :ruby
-  end
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
   gem 'beaker-puppet_install_helper',  :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,11 +38,6 @@ end
 
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
-  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
   gem 'beaker-puppet_install_helper',  :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,11 @@ end
 
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
+  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
+    gem 'beaker-rspec', *location_for(beaker_rspec_version)
+  else
+    gem 'beaker-rspec',  :require => false
+  end
   gem 'beaker-puppet_install_helper',  :require => false
 end
 


### PR DESCRIPTION
Further restrict down the restrictions on windows dependencies when
using older Puppet versions, such that it works with Puppet 3.0.0 -
3.7.0. It does require a bit more logic in selecting gems but it allows
for testing older platforms without any additional known issues for
Puppet versions under 3.4.0.