### PR TITLE
(maint) Guarantee Facter version for old Puppets / (MODULES-2452) Update Beaker Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,23 +73,27 @@ if explicitly_require_windows_gems
   # This also means Puppet Gem less than 3.5.0 - this has been tested back
   # to 3.0.0. Any further back is likely not supported.
   if puppet_gem_location == :gem
-    gem "ffi", "1.9.0",               :require => false
-    gem "win32-eventlog", "0.5.3",    :require => false
-    gem "win32-process", "0.6.5",     :require => false
-    gem "win32-security", "~> 0.1.2", :require => false
-    gem "win32-service", "0.7.2",     :require => false
-    gem "minitar", "0.5.4",           :require => false
+    gem "ffi", "1.9.0",                 :require => false
+    gem "win32-eventlog", "0.5.3",      :require => false
+    gem "win32-process", "0.6.5",       :require => false
+    gem "win32-security", "~> 0.1.2",   :require => false
+    gem "win32-service", "0.7.2",       :require => false
+    gem "minitar", "0.5.4",             :require => false
+    # If facterversion hasn't been specified and we are
+    # looking for a Puppet Gem version less than 3.5.0, we
+    # need to ensure we get a good Facter for Windows specs.
+    gem "facter",">= 1.6.11","<= 1.7.5",:require => false unless facterversion
   else
-    gem "ffi", "~> 1.9.0",            :require => false
-    gem "win32-eventlog", "~> 0.5",   :require => false
-    gem "win32-process", "~> 0.6",    :require => false
-    gem "win32-security", "~> 0.1",   :require => false
-    gem "win32-service", "~> 0.7",    :require => false
-    gem "minitar", "~> 0.5.4",        :require => false
+    gem "ffi", "~> 1.9.0",              :require => false
+    gem "win32-eventlog", "~> 0.5",     :require => false
+    gem "win32-process", "~> 0.6",      :require => false
+    gem "win32-security", "~> 0.1",     :require => false
+    gem "win32-service", "~> 0.7",      :require => false
+    gem "minitar", "~> 0.5.4",          :require => false
   end
 
-  gem "win32-dir", "~> 0.3",          :require => false
-  gem "win32console", "1.3.2",        :require => false if RUBY_VERSION =~ /^1\./
+  gem "win32-dir", "~> 0.3",            :require => false
+  gem "win32console", "1.3.2",          :require => false if RUBY_VERSION =~ /^1\./
 
   # Puppet less than 3.7.0 requires these.
   # Puppet 3.5.0+ will control the actual requirements.
@@ -98,11 +102,11 @@ if explicitly_require_windows_gems
   # We do not want to allow newer versions than what came out after
   # 3.6.x to be used as they constitute some risk in breaking older
   # functionality. So we set these to exact versions.
-  gem "sys-admin", "1.5.6",           :require => false
-  gem "win32-api", "1.4.8",           :require => false
-  gem "win32-taskscheduler", "0.2.2", :require => false
-  gem "windows-api", "0.4.3",         :require => false
-  gem "windows-pr",  "1.2.3",         :require => false
+  gem "sys-admin", "1.5.6",             :require => false
+  gem "win32-api", "1.4.8",             :require => false
+  gem "win32-taskscheduler", "0.2.2",   :require => false
+  gem "windows-api", "0.4.3",           :require => false
+  gem "windows-pr",  "1.2.3",           :require => false
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
 end
 
 group :system_tests do
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'beaker-puppet_install_helper',  :require => false
 end
 


### PR DESCRIPTION
For Puppet older than 3.5.0 on Windows, a facter version at or under
1.7.5 should be selected for greatest compatibility when requesting
a gem puppet version and if a facter version has not been specified.

Update the Beaker version to use "2.20" which has an important fix for PE
installations.