### PR TITLE
(MODULES-2657) Detect Windows computer rename

### DIFF
--- a/acceptance/tests/windows/reboot_pending.rb
+++ b/acceptance/tests/windows/reboot_pending.rb
@@ -38,3 +38,27 @@ windows_agents.each do |agent|
   #Verify that a shutdown has been initiated and clear the pending shutdown.
   retry_shutdown_abort(agent)
 end
+
+windows_agents.each do |agent|
+  original_name = nil
+
+  begin
+    step "Retrieve computer name"
+    original_name = on(agent, 'cmd /c hostname').stdout.chomp
+
+    new_name = ('a'..'z').to_a.shuffle[0, 12].join
+    step "Rename the computer to #{new_name} temporarily"
+    on agent, powershell("\"& { (Get-WmiObject -Class Win32_ComputerSystem).Rename('#{new_name}') }\"")
+
+    step "Reboot if Pending Reboot Required"
+    apply_manifest_on agent,  reboot_manifest
+
+    #Verify that a shutdown has been initiated and clear the pending shutdown.
+    retry_shutdown_abort(agent)
+  ensure
+    if original_name
+      step "Rename the computer back to #{original_name}"
+      on agent, powershell("\"& { (Get-WmiObject win32_computersystem).Rename('#{original_name}') }\"")
+    end
+  end
+end

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -76,7 +76,8 @@ Puppet::Type.type(:reboot).provide :windows do
       windows_auto_update? ||
       pending_file_rename_operations? ||
       package_installer? ||
-      package_installer_syswow64?
+      package_installer_syswow64? ||
+      pending_computer_rename?
   end
 
   def vista_sp1_or_later?
@@ -142,6 +143,19 @@ Puppet::Type.type(:reboot).provide :windows do
       false
     end
   end
+
+  def pending_computer_rename?
+    path = 'SYSTEM\CurrentControlSet\Control\ComputerName'
+    active_name = reg_value("#{path}\\ActiveComputerName", 'ComputerName')
+    pending_name = reg_value("#{path}\\ComputerName", 'ComputerName')
+    if active_name && pending_name && active_name != pending_name
+      Puppet.debug("Pending reboot: Computer being renamed from #{active_name} to #{pending_name}")
+      true
+    else
+      false
+    end
+  end
+
 
   private
 

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -308,6 +308,41 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         end
       end
     end
+
+    context 'Pending computer rename' do
+      let(:active_path) { 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' }
+      let(:pending_path) { 'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' }
+      let(:reg_name) { 'ComputerName' }
+
+      it 'reboots if the pending computer name exists and does not match active computer name' do
+        expects_registry_value(active_path, reg_name, 'Foo')
+        expects_registry_value(pending_path, reg_name, 'Bar')
+
+        provider.should be_pending_computer_rename
+      end
+
+      it 'ignores if the pending computer name matches active computer name' do
+        computer_name = 'Foo'
+        expects_registry_value(active_path, reg_name, computer_name)
+        expects_registry_value(pending_path, reg_name, computer_name)
+
+        provider.should_not be_pending_computer_rename
+      end
+
+      it 'ignores if the active computer name key is absent' do
+        expects_registry_key_not_found(active_path)
+        expects_registry_value(pending_path, reg_name, 'Foo')
+
+        provider.should_not be_pending_computer_rename
+      end
+
+      it 'ignores if pending computer name key is absent' do
+        expects_registry_value(active_path, reg_name, 'Foo')
+        expects_registry_key_not_found(pending_path)
+
+        provider.should_not be_pending_computer_rename
+      end
+    end
   end
 
 end


### PR DESCRIPTION
 - A pending computer rename operation is a trigger for a reboot, even
   though it is not expressed in any of the existing checks.

  This is due to the fact that the Windows API GetComputerName function
  reads the NetBIOS name of the computer from the registry on first boot
  and caches it for all of eternity.  See docs at:

  https://msdn.microsoft.com/en-us/library/windows/desktop/ms724295(v=vs.85).aspx