### PR TITLE
(maint) Emit Windows debug messages for pending

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -173,6 +173,7 @@ Puppet::Type.type(:reboot).provide :windows do
     rescue
     end
 
+    Puppet.debug("Pending reboot: DSC LocalConfigurationManager LCMState") if reboot
     reboot
   end
 
@@ -191,6 +192,7 @@ Puppet::Type.type(:reboot).provide :windows do
     rescue
     end
 
+    Puppet.debug("Pending reboot: CCM ClientUtilities") if reboot
     reboot
   end
 


### PR DESCRIPTION
 - Prior commits failed to add appropriate debug messages to notify
   what system settings were responsible for setting a system reboot
   state.