### PR TITLE
(MODULES-2804) fix the misuse of read method of Win32::Registry

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:reboot).provide :windows do
     with_key(path) do |reg|
       renames = reg.read('PendingFileRenameOperations') rescue nil
       if renames
-        pending = renames.length > 0
+        pending = renames[1].length > 0
         if pending
           Puppet.debug("Pending reboot: HKLM\\PendingFileRenameOperations")
         end
@@ -214,7 +214,7 @@ Puppet::Type.type(:reboot).provide :windows do
     rval = nil
 
     with_key(path) do |reg|
-      rval = reg.read(value)
+      rval = reg.read(value)[1]
     end
 
     rval

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -180,7 +180,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
 
     def expects_registry_value(path, name, value)
       reg = stub('reg')
-      reg.expects(:read).with(name).returns(value)
+      reg.expects(:read).with(name).returns(['whatever_type', value])
       expects_registry_key(path).yields(reg)
     end
 


### PR DESCRIPTION
Please refer to the following issue ticket.
https://tickets.puppetlabs.com/browse/MODULES-2804