### PR TITLE
(MODULES-2822) Windows provider reboot_required

### DIFF
--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -3,6 +3,7 @@ Puppet::Type.type(:reboot).provide :windows do
   defaultfor :operatingsystem => :windows
 
   has_features :manages_reboot_pending
+  attr_accessor :reboot_required
 
   def self.shutdown_command
     if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
@@ -72,7 +73,8 @@ Puppet::Type.type(:reboot).provide :windows do
   def reboot_pending?
     # http://gallery.technet.microsoft.com/scriptcenter/Get-PendingReboot-Query-bdb79542
 
-    component_based_servicing? ||
+    reboot_required ||
+      component_based_servicing? ||
       windows_auto_update? ||
       pending_file_rename_operations? ||
       package_installer? ||

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -463,6 +463,24 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         end
       end
     end
+
+    context 'With required_reboot provider property' do
+      it 'does not reboot by default' do
+        provider.should_not be_reboot_pending
+      end
+
+      it 'reboots when reboot_required is set to true' do
+        provider.reboot_required = true
+
+        provider.should be_reboot_pending
+      end
+
+      it 'does not reboot when reboot_required is set to false' do
+        provider.reboot_required = false
+
+        provider.should_not be_reboot_pending
+      end
+    end
   end
 
 end


### PR DESCRIPTION
 - Adds a new value to the Windows specific provider implementation that
   can be set to notify of a pending reboot.
 - This has been added primarily for the sake of DSC, which needs a way
   to ask for a reboot on demand, since the Invoke-DscResource cmdlet in
   PowerShell does not propagate a global status anywhere.

   See https://tickets.puppetlabs.com/browse/MODULES-2641

   Sample usage from within another module looks something like:

   resource.catalog.resource(:reboot, 'dsc_reboot')
   if reboot_resource.provider.respond_to?(:reboot_required)
     reboot_resource.provider.reboot_required = true
   else