### PR TITLE
Revert "(maint) Use appropriate conditionals"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.1.x.{build}
 skip_commits:
-  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+  message: /(^\(?doc\)?.*)/
 clone_depth: 10
 init:
 - SET

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -85,7 +85,8 @@ Puppet::Type.type(:reboot).provide :windows do
   end
 
   def vista_sp1_or_later?
-    match = Facter[:kernelversion].value.match(/\d+\.\d+\.(\d+)/) && match[1].to_i >= 6001
+    # this errors if this is not a control flow construct
+    match = Facter[:kernelversion].value.match(/\d+\.\d+\.(\d+)/) and match[1].to_i >= 6001
   end
 
   def component_based_servicing?
@@ -127,7 +128,8 @@ Puppet::Type.type(:reboot).provide :windows do
     # 0x00000000 (0)	No pending restart.
     path = 'SOFTWARE\Microsoft\Updates'
     value = reg_value(path, 'UpdateExeVolatile')
-    if value && value != 0
+     # this may error if this is not a control flow construct
+    if value and value != 0
       Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
       true
     else
@@ -140,7 +142,8 @@ Puppet::Type.type(:reboot).provide :windows do
     # 0x00000000 (0)	No pending restart.
     path = 'SOFTWARE\Wow6432Node\Microsoft\Updates'
     value = reg_value(path, 'UpdateExeVolatile')
-    if value && value != 0
+    # this may error if this is not a control flow construct
+    if value and value != 0
       Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
       true
     else


### PR DESCRIPTION
This reverts commit 05b7ce404b0b3fd5b2cfd4b88e864f1445626d2a.

During acceptance testing it was found that this causes issues
in particular versions of Ruby. So we'll move back to control
flow conditionals for now.