### PR TITLE
(maint) Update rakefile for puppetlabs_spec_helper

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,4 +20,9 @@ end
 
 PuppetLint.configuration.fail_on_warnings
 PuppetLint.configuration.send('disable_autoloader_layout')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp","tests/*.pp"]
+
+# These lint exclusions are in puppetlabs_spec_helper but needs a version above 0.10.3 
+# Line length test is 80 chars in puppet-lint 1.1.0
+PuppetLint.configuration.send('disable_80chars')
+# Line length test is 140 chars in puppet-lint 2.x
+PuppetLint.configuration.send('disable_140chars')


### PR DESCRIPTION
The rakefile is attempting to override the default puppet lint settings however
these settings are more permissive than the defaults and are causing false
lint failures e.g. the vendor directory is not excluded in thie Rakefile but
the puppetlabs_spec_helper does this by default.  This commit removes the
ignore_paths setting as the spec helper already does this.  Also added a comment
that the 80 and 140 char rule changes can be removed once next version of
spec_helper is released as they are already the defaults.