### PR TITLE
(maint) Update module for use with PE 2016.2

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,25 +6,11 @@
     env: PUPPET_GEM_VERSION="3.3.0"
 Gemfile:
   supports_windows: true
-  required:
+  optional:
     ':development':
-      - gem: rake
-      - gem: rspec
-        version: '~>2.14.1'
-      - gem: puppet-lint
-      - gem: puppetlabs_spec_helper
-        version: '~>0.10.3'
-      - gem: puppet_facts
-      - gem: mocha
-        version: '~>0.10.5'
       - gem: 'nokogiri'
         version: '~>1.5.10'
         platforms: ':ruby'
-      - gem: 'mime-types'
-        version: '<2.0'
-    ':system_tests':
-      - gem: beaker
-      - gem: beaker-puppet_install_helper
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -37,16 +37,17 @@ end
 
 group :development do
   gem 'rake',                                :require => false
-  gem 'rspec', '~>2.14.1',                   :require => false
+  gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
+  gem 'pry',                                 :require => false
   gem 'nokogiri', '~>1.5.10',                :require => false, :platforms => :ruby
-  gem 'mime-types', '<2.0',                  :require => false
 end
 
 group :system_tests do
+  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'beaker-puppet_install_helper',  :require => false
 end

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -466,13 +466,13 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
 
     context 'with reboot_required provider property' do
       it 'does not indicate a reboot by default' do
-        provider.reboot_required.should be_false
+        expect(provider.reboot_required).to be_falsey
       end
 
       it 'reboots when reboot_required is set to true' do
         provider.reboot_required = true
 
-        provider.should be_reboot_pending
+        expect(provider.reboot_pending?).to be (true)
       end
 
       it 'does not reboot when reboot_required is set to false' do
@@ -488,7 +488,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         provider.expects(:pending_dsc_reboot?).returns(false)
         provider.expects(:pending_ccm_reboot?).returns(false)
 
-        provider.should_not be_reboot_pending
+        expect(provider.reboot_pending?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
The gem specification for mimetypes was causing an old version of beaker to be installed.
This version of beaker is not compatible with 2016.2 as it is unable to use the beaker-answers
gem as 2016.2 is installed using MEEP.  The mimetypes specification appears to be a hold over
from copying sync.yml from the acl project.  This commit keeps the nokogiri gem requirement
but uses the optional gems notation in the sync.yml so that the defaults from modsync still
get applied.

This commit also updates Gemfile with modsync.

Previously RSpec was pinned to an old version (2.x) however this is no longer
the case.  Three tests were causing CI failures due to using the older should
syntax.  This commit updates these tests using the newer expect syntax.