### PR TITLE
(MODULES-4328) Implement reboot reason for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ By default, when this module triggers a reboot, it skips any resources in the ca
       apply  => finished,
     }
 
+### Reboot when certain conditions are met (Windows Only)
+
+When using `when => pending`, there are a number of reasons why a reboot might be pending. `onlyif` or `unless` can be used to specify which reasons you care about.
+
+    reboot { 'reboot on file renames':
+      when   => 'pending',
+      onlyif => 'pending_file_rename_operations'
+    }
+
+The possible reasons for rebooting are:
+
+* reboot_required - A reboot has manually been requested through the provider
+* component_based_servicing - New component has been installed (We think, no good docs on this registry key)
+* windows_auto_update - Automatic update requested a reboot
+* pending_file_rename_operations - There are files that need to be renamed at the next reboot
+* package_installer - A software update requested a reboot
+* package_installer_syswow64 - A software update requested a reboot
+* pending_computer_rename - The computer needs to be renamed
+* pending_dsc_reboot - DSC has requested a reboot
+* pending_ccm_reboot - CCM has requested a reboot
+
+
 ## Reference
 
 ### Type: reboot
@@ -118,6 +140,40 @@ The main type of the module, responsible for all its functionality.
 *Optional.* Specifies how reboots are triggered. If set to 'refreshed', the provider only reboots the node in response to a refresh event from another resource, e.g., installing a package. If set to 'pending', Puppet checks for signs of any pending reboots and completes them before applying the next resource in the catalog. Valid options: 'refreshed' and 'pending'. Default value: 'refreshed'.
 
 **Note:** For `when => pending` reboots, Puppet can normally detect a pending reboot based on some specific system conditions (such as the existence of the PendingFileRenameOperations registry key). However, if those conditions aren't resolved after the node reboots, Puppet triggers another reboot. This can lead to a reboot loop.
+
+#### `onlyif`
+
+*Optional.* Applies a pending reboot only for the specified reasons.
+This can take a single reason or an array of reasons.
+
+The possible reasons for rebooting are:
+
+* reboot_required - A reboot has manually been requested through the provider
+* component_based_servicing - New component has been installed (We think, no good docs on this registry key)
+* windows_auto_update - Automatic update requested a reboot
+* pending_file_rename_operations - There are files that need to be renamed at the next reboot
+* package_installer - A software update requested a reboot
+* package_installer_syswow64 - A software update requested a reboot
+* pending_computer_rename - The computer needs to be renamed
+* pending_dsc_reboot - DSC has requested a reboot
+* pending_ccm_reboot - CCM has requested a reboot
+
+#### `unless`
+
+*Optional.* Ignores the specified reasons when checking for a pending reboot.
+This can take a single reason or an array of reasons.
+
+The possible reasons for rebooting are:
+
+* reboot_required - A reboot has manually been requested through the provider
+* component_based_servicing - New component has been installed (We think, no good docs on this registry key)
+* windows_auto_update - Automatic update requested a reboot
+* pending_file_rename_operations - There are files that need to be renamed at the next reboot
+* package_installer - A software update requested a reboot
+* package_installer_syswow64 - A software update requested a reboot
+* pending_computer_rename - The computer needs to be renamed
+* pending_dsc_reboot - DSC has requested a reboot
+* pending_ccm_reboot - CCM has requested a reboot
 
 ## Development
 

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -491,6 +491,42 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         expect(provider.reboot_pending?).to be_falsey
       end
     end
+
+    context 'with onlyif provider property' do
+      it 'does not reboot when onlyif is set' do
+        resource[:onlyif] = [:pending_dsc_reboot]
+        resource[:when] = :pending
+
+        #provider.expects(:component_based_servicing?).returns(true)
+        #provider.expects(:windows_auto_update?).returns(true)
+        #provider.expects(:pending_file_rename_operations?).returns(true)
+        #provider.expects(:package_installer?).returns(true)
+        #provider.expects(:package_installer_syswow64?).returns(true)
+        #provider.expects(:pending_computer_rename?).returns(true)
+        provider.expects(:pending_dsc_reboot?).returns(false)
+        #provider.expects(:pending_ccm_reboot?).returns(true)
+
+        expect(provider.reboot_pending?).to be_falsey
+      end
+    end
+
+    context 'with unless provider property' do
+      it 'does not reboot when unless is set' do
+        resource[:unless] = [:pending_dsc_reboot]
+        resource[:when] = :pending
+
+        provider.expects(:component_based_servicing?).returns(false)
+        provider.expects(:windows_auto_update?).returns(false)
+        provider.expects(:pending_file_rename_operations?).returns(false)
+        provider.expects(:package_installer?).returns(false)
+        provider.expects(:package_installer_syswow64?).returns(false)
+        provider.expects(:pending_computer_rename?).returns(false)
+        #provider.expects(:pending_dsc_reboot?).returns(true)
+        provider.expects(:pending_ccm_reboot?).returns(false)
+
+        expect(provider.reboot_pending?).to be_falsey
+      end
+    end
   end
 
 end

--- a/spec/unit/type/reboot_spec.rb
+++ b/spec/unit/type/reboot_spec.rb
@@ -119,6 +119,70 @@ describe Puppet::Type.type(:reboot) do
     end
   end
 
+  context "parameter :onlyif" do
+    it "should default :onlyif to nil" do
+      resource[:onlyif].must == nil
+    end
+
+    it "should accept package_installer reason" do
+      resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+      resource[:onlyif] = [:package_installer]
+    end
+
+    it "should accept package_installer reason" do
+      resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+      resource[:onlyif] = :package_installer
+    end
+
+    it "shouldn't accept an empty list" do
+      expect {
+        resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+        resource[:onlyif] = []
+      }.to raise_error(Puppet::ResourceError, /There must be at least one element in the list/)
+    end
+
+    ["pks_install", :pkg_install, {}, true].each do |reason|
+      it "should reject invalid reasons (#{reason})" do
+        expect {
+          resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+          resource[:onlyif] = reason
+        }.to raise_error(Puppet::ResourceError, /value must be one of/)
+      end
+    end
+  end
+
+  context "parameter :unless" do
+    it "should default :timeout to nil" do
+      resource[:unless].must == nil
+    end
+
+    it "should accept package_installer reason" do
+      resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+      resource[:unless] = [:package_installer]
+    end
+
+    it "should accept package_installer reason" do
+      resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+      resource[:unless] = :package_installer
+    end
+
+    it "shouldn't accept an empty list" do
+      expect {
+        resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+        resource[:unless] = []
+      }.to raise_error(Puppet::ResourceError, /There must be at least one element in the list/)
+    end
+
+    ["pks_install", :pkg_install, {}, true].each do |reason|
+      it "should reject invalid reasons (#{reason})" do
+        expect {
+          resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
+          resource[:unless] = reason
+        }.to raise_error(Puppet::ResourceError, /value must be one of/)
+      end
+    end
+  end
+
   context "multiple reboot resources" do
     let(:resource2) { Puppet::Type.type(:reboot).new(:name => "reboot2") }
     let(:provider2) { Puppet::Provider.new(resource2) }


### PR DESCRIPTION
When we set `when => pending`, there are a number of events that will
cause a reboot.

Introduce `onlyif` and `except` so we can filter on the events we care
about.