### PR TITLE
(maint) bump nokogiri pin

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,7 +3,7 @@ Gemfile:
   optional:
     ':development':
       - gem: 'nokogiri'
-        version: '~>1.5.10'
+        version: '~>1.8.1'
         platforms: 'ruby'
 Rakefile:
   unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "nokogiri", '~>1.5.10',                             :require => false, :platforms => "ruby"
+  gem "nokogiri", '~>1.8.1',                              :require => false, :platforms => "ruby"
 end
 
 group :system_tests do


### PR DESCRIPTION
As per Github, there is a known security issue in nokogiri < 1.8.1 . I was not sure if removing the pin was ok so I just bumped it to ~> 1.8.1 in .sync.yml and the Gemfile.