### PR TITLE
(MAINT) move test dependences from metadata to spec_helper_acceptnace

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -89,14 +89,5 @@
     }
   ],
   "description": "This module provides a facility for managing reboots across nodes.",
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.1.0 < 2.0.0"
-    }
-  ]
+  "dependencies": []
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,6 +12,10 @@ test_name 'Installing Puppet Modules' do
   local = { :module_name => 'reboot', :source => proj_root }
 
   hosts.each do |host|
+    step 'Install Reboot Module Dependencies'
+    on(host, puppet('module install puppetlabs-stdlib'))
+    on(host, puppet('module install puppetlabs-registry'))
+
     step 'Install Reboot Module'
     # in CI allow install from staging forge, otherwise from local
     install_dev_puppet_module_on(host, options[:forge_host] ? staging : local)


### PR DESCRIPTION
Moved the test dependencies of stdlib and registry from metadata.json to install from the forge via a beaker on(host) call inside of spec_helper_acceptance.
