### PR TITLE
(MODULES-5896)(MODULES-3975) Fix rubocop violations

### DIFF
--- a/lib/puppet/provider/reboot/linux.rb
+++ b/lib/puppet/provider/reboot/linux.rb
@@ -1,8 +1,8 @@
 require 'pathname'
 require Pathname.new(__FILE__).dirname + '../../../' + 'puppet/provider/reboot/posix'
 
-Puppet::Type.type(:reboot).provide :linux, :parent => :posix do
-  confine :kernel => :linux
+Puppet::Type.type(:reboot).provide :linux, parent: :posix do
+  confine kernel: :linux
 
   def initialize(resource = nil)
     Puppet.deprecation_warning "The 'linux' reboot provider is deprecated and will be removed; use 'posix' instead."

--- a/lib/puppet/provider/reboot/posix.rb
+++ b/lib/puppet/provider/reboot/posix.rb
@@ -4,11 +4,11 @@ Puppet::Type.type(:reboot).provide :posix do
   This provider handles rebooting for POSIX systems. It does not support
   HP-UX."
 
-  confine :feature => :posix
-  confine :false => (Facter.value(:kernel) == 'HP-UX')
-  defaultfor :feature => :posix
+  confine feature: :posix
+  confine false: (Facter.value(:kernel) == 'HP-UX')
+  defaultfor feature: :posix
 
-  commands :shutdown => 'shutdown'
+  commands shutdown: 'shutdown'
 
   def shutdown_flags
     case Facter.value(:kernel)
@@ -28,8 +28,7 @@ Puppet::Type.type(:reboot).provide :posix do
     :absent
   end
 
-  def when=(value)
-  end
+  def when=(value); end
 
   def cancel_transaction
     Puppet::Application.stop!
@@ -42,7 +41,7 @@ Puppet::Type.type(:reboot).provide :posix do
 
     shutdown_path = command(:shutdown)
     unless shutdown_path
-      raise ArgumentError, "The shutdown command was not found."
+      raise ArgumentError, 'The shutdown command was not found.'
     end
 
     timeout = @resource[:timeout].to_i

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -105,8 +105,8 @@ Puppet::Type.type(:reboot).provide :windows do
   end
 
   def vista_sp1_or_later?
-    # this errors if this is not a control flow construct
-    match = Facter[:kernelversion].value.match(%r{\d+\.\d+\.(\d+)}) and match[1].to_i >= 6001
+    match = Facter[:kernelversion].value.match(%r{\d+\.\d+\.(\d+)})
+    match.nil? ? false : match[1].to_i >= 6001
   end
 
   def component_based_servicing?
@@ -152,13 +152,9 @@ Puppet::Type.type(:reboot).provide :windows do
     # 0x00000000 (0)	No pending restart.
     path = 'SOFTWARE\Microsoft\Updates'
     value = reg_value(path, 'UpdateExeVolatile')
-    # this may error if this is not a control flow construct
-    if value and value != 0
-      Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
-      true
-    else
-      false
-    end
+    return false if value.nil? || value.zero?
+    Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
+    true
   end
 
   def package_installer_syswow64?
@@ -166,13 +162,9 @@ Puppet::Type.type(:reboot).provide :windows do
     # 0x00000000 (0)	No pending restart.
     path = 'SOFTWARE\Wow6432Node\Microsoft\Updates'
     value = reg_value(path, 'UpdateExeVolatile')
-    # this may error if this is not a control flow construct
-    if value and value != 0
-      Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
-      true
-    else
-      false
-    end
+    return false if value.nil? || value.zero?
+    Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
+    true
   end
 
   def pending_computer_rename?

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -1,21 +1,21 @@
 Puppet::Type.type(:reboot).provide :windows do
-  confine :operatingsystem => :windows
-  defaultfor :operatingsystem => :windows
+  confine operatingsystem: :windows
+  defaultfor operatingsystem: :windows
 
   has_features :manages_reboot_pending
   attr_accessor :reboot_required
 
   def self.shutdown_command
-    if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
+    if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
       "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe"
-    elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
+    elsif File.exist?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
       "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe"
     else
       'shutdown.exe'
     end
   end
 
-  commands :shutdown => shutdown_command
+  commands shutdown: shutdown_command
 
   def self.instances
     []
@@ -30,14 +30,13 @@ Puppet::Type.type(:reboot).provide :windows do
     end
   end
 
-  def when=(value)
-    if @resource[:when] == :pending
-      if @resource.class.rebooting
-        Puppet.debug("Reboot already scheduled; skipping")
-      else
-        @resource.class.rebooting = true
-        reboot
-      end
+  def when=(_value)
+    return unless @resource[:when] == :pending
+    if @resource.class.rebooting
+      Puppet.debug('Reboot already scheduled; skipping')
+    else
+      @resource.class.rebooting = true
+      reboot
     end
   end
 
@@ -47,7 +46,8 @@ Puppet::Type.type(:reboot).provide :windows do
 
   def reboot
     if @resource[:apply] == :finished && @resource[:when] == :pending
-      Puppet.warning("The combination of `when => pending` and `apply => finished` is not a recommended or supported scenario. Please only use this scenario if you know exactly what you are doing. The puppet agent run will continue.")
+      Puppet.warning('The combination of `when => pending` and `apply => finished` is not a recommended or supported scenario. Please only use this scenario \
+                      if you know exactly what you are doing. The puppet agent run will continue.')
     end
 
     if @resource[:apply] != :finished
@@ -56,7 +56,7 @@ Puppet::Type.type(:reboot).provide :windows do
 
     shutdown_path = command(:shutdown)
     unless shutdown_path
-      raise ArgumentError, "The shutdown.exe command was not found. On Windows 2003 x64 hotfix 942589 must be installed to access the 64-bit version of shutdown.exe from 32-bit version of ruby.exe."
+      raise ArgumentError, 'The shutdown.exe command was not found. On Windows 2003 x64 hotfix 942589 must be installed to access the 64-bit version of shutdown.exe from 32-bit version of ruby.exe.'
     end
 
     # Reason code
@@ -85,7 +85,7 @@ Puppet::Type.type(:reboot).provide :windows do
       :package_installer_syswow64,
       :pending_computer_rename,
       :pending_dsc_reboot,
-      :pending_ccm_reboot
+      :pending_ccm_reboot,
     ]
 
     if @resource[:onlyif] && @resource[:unless]
@@ -93,7 +93,7 @@ Puppet::Type.type(:reboot).provide :windows do
     end
 
     reasons = @resource[:onlyif] if @resource[:onlyif]
-    reasons = reasons - @resource[:unless] if @resource[:unless]
+    reasons -= @resource[:unless] if @resource[:unless]
 
     result = false
 
@@ -106,7 +106,7 @@ Puppet::Type.type(:reboot).provide :windows do
 
   def vista_sp1_or_later?
     # this errors if this is not a control flow construct
-    match = Facter[:kernelversion].value.match(/\d+\.\d+\.(\d+)/) and match[1].to_i >= 6001
+    match = Facter[:kernelversion].value.match(%r{\d+\.\d+\.(\d+)}) and match[1].to_i >= 6001
   end
 
   def component_based_servicing?
@@ -131,11 +131,15 @@ Puppet::Type.type(:reboot).provide :windows do
 
     path = 'SYSTEM\CurrentControlSet\Control\Session Manager'
     with_key(path) do |reg|
-      renames = reg.read('PendingFileRenameOperations') rescue nil
+      renames = begin
+                  reg.read('PendingFileRenameOperations')
+                rescue
+                  nil
+                end
       if renames
-        pending = renames[1].length > 0
+        pending = !renames[1].empty?
         if pending
-          Puppet.debug("Pending reboot: HKLM\\PendingFileRenameOperations")
+          Puppet.debug('Pending reboot: HKLM\\PendingFileRenameOperations')
         end
       end
     end
@@ -148,7 +152,7 @@ Puppet::Type.type(:reboot).provide :windows do
     # 0x00000000 (0)	No pending restart.
     path = 'SOFTWARE\Microsoft\Updates'
     value = reg_value(path, 'UpdateExeVolatile')
-     # this may error if this is not a control flow construct
+    # this may error if this is not a control flow construct
     if value and value != 0
       Puppet.debug("Pending reboot: HKLM\\#{path}\\UpdateExeVolatile=#{value}")
       true
@@ -195,10 +199,11 @@ Puppet::Type.type(:reboot).provide :windows do
 
       config = lcm.ExecMethod_('GetMetaConfiguration')
       reboot = config.MetaConfiguration.LCMState == 'PendingReboot'
-    rescue
+    rescue # rubocop:disable Lint/HandleExceptions
+      # WIN32OLE errors are very bad to diagnose.  In this case any errors are ignored.
     end
 
-    Puppet.debug("Pending reboot: DSC LocalConfigurationManager LCMState") if reboot
+    Puppet.debug('Pending reboot: DSC LocalConfigurationManager LCMState') if reboot
     reboot
   end
 
@@ -213,17 +218,18 @@ Puppet::Type.type(:reboot).provide :windows do
       ccm_client_utils = ccm.Get('CCM_ClientUtilities')
 
       pending = ccm_client_utils.ExecMethod_('DetermineIfRebootPending')
-      reboot = (pending.ReturnValue == 0) && (pending.IsHardRebootPending || pending.RebootPending)
-    rescue
+      reboot = pending.ReturnValue.zero? && (pending.IsHardRebootPending || pending.RebootPending)
+    rescue # rubocop:disable Lint/HandleExceptions
+      # WIN32OLE errors are very bad to diagnose.  In this case any errors are ignored.
     end
 
-    Puppet.debug("Pending reboot: CCM ClientUtilities") if reboot
+    Puppet.debug('Pending reboot: CCM ClientUtilities') if reboot
     reboot
   end
 
   private
 
-  def with_key(name, &block)
+  def with_key(name)
     require 'win32/registry'
 
     Win32::Registry::HKEY_LOCAL_MACHINE.open(name, Win32::Registry::KEY_READ | 0x100) do |reg|

--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -63,10 +63,10 @@ Puppet::Type.newtype(:reboot) do
         }
   EOT
 
-  feature :manages_reboot_pending, "The provider can detect if a reboot is pending, and reboot as needed."
+  feature :manages_reboot_pending, 'The provider can detect if a reboot is pending, and reboot as needed.'
 
   newparam(:name) do
-    desc "The name of the reboot resource.  Used for uniqueness."
+    desc 'The name of the reboot resource.  Used for uniqueness.'
     isnamevar
   end
 
@@ -77,7 +77,7 @@ Puppet::Type.newtype(:reboot) do
       will only be performed in response to a refresh event from
       another resource, e.g. `package`."
     newvalue(:refreshed)
-    newvalue(:pending, :required_features => :manages_reboot_pending)
+    newvalue(:pending, required_features: :manages_reboot_pending)
     defaultto :refreshed
 
     def insync?(is)
@@ -90,7 +90,7 @@ Puppet::Type.newtype(:reboot) do
     end
   end
 
-  newparam(:onlyif, :required_features => [:manages_reboot_pending]) do
+  newparam(:onlyif, required_features: [:manages_reboot_pending]) do
     desc "For pending reboots, only reboot if the reboot is pending
       for one of the supplied reasons."
 
@@ -102,7 +102,7 @@ Puppet::Type.newtype(:reboot) do
 
     validate do |values|
       if values == []
-        raise ArgumentError, "There must be at least one element in the list"
+        raise ArgumentError, 'There must be at least one element in the list'
       end
 
       values = [values] unless values.is_a?(Array)
@@ -123,8 +123,8 @@ Puppet::Type.newtype(:reboot) do
     end
   end
 
-  newparam(:unless, :required_features => [:manages_reboot_pending]) do
-    desc "For pending reboots, ignore the supplied reasons when checking pennding reboot"
+  newparam(:unless, required_features: [:manages_reboot_pending]) do
+    desc 'For pending reboots, ignore the supplied reasons when checking pennding reboot'
 
     possible_values = [
       :reboot_required, :component_based_servicing, :windows_auto_update,
@@ -134,7 +134,7 @@ Puppet::Type.newtype(:reboot) do
 
     validate do |values|
       if values == []
-        raise ArgumentError, "There must be at least one element in the list"
+        raise ArgumentError, 'There must be at least one element in the list'
       end
 
       values = [values] unless values.is_a?(Array)
@@ -166,21 +166,21 @@ Puppet::Type.newtype(:reboot) do
   end
 
   newparam(:message) do
-    desc "The message to log when the reboot is performed."
+    desc 'The message to log when the reboot is performed.'
 
     validate do |value|
-      if value.nil? or value == ""
-        raise ArgumentError, "A non-empty message must be specified."
+      if value.nil? || value == ''
+        raise ArgumentError, 'A non-empty message must be specified.'
       end
 
       # Maximum command line length in Windows is 8191 characters, so this is
       # an approximation based on the other parts of the shutdown command
       if value.length > 8000
-        raise ArgumentError, "The given message must not exceed 8000 characters."
+        raise ArgumentError, 'The given message must not exceed 8000 characters.'
       end
     end
 
-    defaultto "Puppet is rebooting the computer"
+    defaultto 'Puppet is rebooting the computer'
   end
 
   newparam(:timeout) do
@@ -190,8 +190,8 @@ Puppet::Type.newtype(:reboot) do
       current run."
 
     validate do |value|
-      if value.to_s !~ /^\d+$/
-        raise ArgumentError, "The timeout must be an integer."
+      if value.to_s !~ %r{^\d+$}
+        raise ArgumentError, 'The timeout must be an integer.'
       end
     end
 
@@ -200,26 +200,26 @@ Puppet::Type.newtype(:reboot) do
 
   @rebooting = false
 
-  def self.rebooting
-    @rebooting
+  class << self
+    attr_reader :rebooting
   end
 
-  def self.rebooting=(value)
-    @rebooting = value
+  class << self
+    attr_writer :rebooting
   end
 
   def refresh
     case self[:when]
     when :refreshed
       if self.class.rebooting
-        Puppet.debug("Reboot already scheduled; skipping")
+        Puppet.debug('Reboot already scheduled; skipping')
       else
         self.class.rebooting = true
         Puppet.notice("Scheduling system reboot with message: \"#{self[:message]}\"")
         provider.reboot
       end
     else
-      Puppet.debug("Skipping reboot")
+      Puppet.debug('Skipping reboot')
     end
   end
 end

--- a/spec/acceptance/reboot_finished_spec.rb
+++ b/spec/acceptance/reboot_finished_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper_acceptance'
 
 describe 'Reboot when Finished' do
-
   def apply_reboot_manifest(agent, reboot_manifest)
     apply_manifest_on agent, reboot_manifest do |result|
-      assert_match /defined 'message' as 'step_2'/,
+      assert_match %r{defined 'message' as 'step_2'},
                    result.stdout, 'Expected step was not finished before reboot'
     end
     retry_shutdown_abort(agent)
   end
 
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       notify { 'step_1':
       } ~>
@@ -20,7 +19,7 @@ describe 'Reboot when Finished' do
       notify { 'step_2':
       }
     MANIFEST
-  }
+  end
 
   windows_agents.each do |agent|
     context "on #{agent}" do

--- a/spec/acceptance/reboot_immediate_spec.rb
+++ b/spec/acceptance/reboot_immediate_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper_acceptance'
 
 describe 'Reboot Immediately and Explicit Immediately' do
-
   def apply_reboot_manifest(agent, reboot_manifest)
     apply_manifest_on agent, reboot_manifest
     retry_shutdown_abort(agent)
   end
 
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       notify { 'step_1':
       }
@@ -15,9 +14,9 @@ describe 'Reboot Immediately and Explicit Immediately' do
       reboot { 'now':
       }
     MANIFEST
-  }
+  end
 
-  let(:reboot_immediate_manifest) {
+  let(:reboot_immediate_manifest) do
     <<-MANIFEST
       notify { 'step_1':
       }
@@ -26,7 +25,7 @@ describe 'Reboot Immediately and Explicit Immediately' do
         apply => immediately
       }
     MANIFEST
-  }
+  end
 
   windows_agents.each do |agent|
     context "on #{agent}" do

--- a/spec/acceptance/reboot_no_refresh_spec.rb
+++ b/spec/acceptance/reboot_no_refresh_spec.rb
@@ -1,17 +1,16 @@
 require 'spec_helper_acceptance'
 
 describe 'No Refresh' do
-
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       reboot { 'now':
       }
     MANIFEST
-  }
+  end
 
   posix_agents.each do |agent|
     context "on #{agent}" do
-      it 'Should not Reboot Computer without Refresh' do
+      it 'does not Reboot Computer without Refresh' do
         apply_manifest_on agent, reboot_manifest
         ensure_shutdown_not_scheduled(agent)
       end
@@ -20,7 +19,7 @@ describe 'No Refresh' do
 
   windows_agents.each do |agent|
     context "on #{agent}" do
-      it 'Should not Reboot Computer without Refresh' do
+      it 'does not Reboot Computer without Refresh' do
         apply_manifest_on agent, reboot_manifest
         ensure_shutdown_not_scheduled(agent)
       end

--- a/spec/acceptance/reboot_pending_spec.rb
+++ b/spec/acceptance/reboot_pending_spec.rb
@@ -1,21 +1,20 @@
 require 'spec_helper_acceptance'
 
 describe 'Windows Provider - Pending Reboot' do
-
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       reboot { 'now':
         when => pending
       }
     MANIFEST
-  }
-  let(:pending_reboot_manifest) {
+  end
+  let(:pending_reboot_manifest) do
     <<-MANIFEST
       registry_key { 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\RebootRequired':
         ensure => present,
       }
     MANIFEST
-  }
+  end
 
   # Undo the Registry Changes for Required Reboot
   after(:all) do
@@ -24,9 +23,9 @@ describe 'Windows Provider - Pending Reboot' do
         ensure => absent,
       }
       MANIFEST
-    windows_agents.each { |agent|
+    windows_agents.each do |agent|
       apply_manifest_on agent, undo_pending_reboot_manifest
-    }
+    end
   end
 
   windows_agents.each do |agent|
@@ -46,7 +45,7 @@ describe 'Windows Provider - Pending Reboot' do
     context "on #{agent}" do
       original_name = on(agent, 'cmd /c hostname').stdout.chomp
 
-      new_name = ('a'..'z').to_a.shuffle[0, 12].join
+      new_name = ('a'..'z').to_a.sample(12).join
       it "Rename the computer to #{new_name} temporarily" do
         on agent, powershell("\"& { (Get-WmiObject -Class Win32_ComputerSystem).Rename('#{new_name}') }\"")
       end

--- a/spec/acceptance/reboot_resume_spec.rb
+++ b/spec/acceptance/reboot_resume_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Puppet Resume after Reboot' do
-
   def apply_reboot_manifest(agent, reboot_manifest, match)
     apply_manifest_on(agent, reboot_manifest) do |result|
       assert_match match, result.stdout, 'Expected file was not created'
@@ -9,7 +8,7 @@ describe 'Puppet Resume after Reboot' do
     retry_shutdown_abort(agent)
   end
 
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       file { '/first.txt':
         ensure => file,
@@ -22,9 +21,9 @@ describe 'Puppet Resume after Reboot' do
       reboot { 'second_reboot':
       }
     MANIFEST
-  }
+  end
 
-  let(:windows_reboot_manifest) {
+  let(:windows_reboot_manifest) do
     <<-MANIFEST
       file { 'c:/first.txt':
         ensure => file,
@@ -37,11 +36,11 @@ describe 'Puppet Resume after Reboot' do
       reboot { 'second_reboot':
       }
     MANIFEST
-  }
+  end
 
   # Remove Test Artifacts
   after(:all) do
-    remove_artifacts =  <<-MANIFEST
+    remove_artifacts = <<-MANIFEST
       file { '/first.txt':
         ensure => absent,
       }
@@ -59,22 +58,22 @@ describe 'Puppet Resume after Reboot' do
       }
       MANIFEST
 
-    posix_agents.each { |agent|
+    posix_agents.each do |agent|
       apply_manifest_on agent, remove_artifacts
-    }
-    windows_agents.each { |agent|
+    end
+    windows_agents.each do |agent|
       apply_manifest_on agent, windows_remove_artifacts
-    }
+    end
   end
 
   posix_agents.each do |agent|
     context "on #{agent}" do
       it 'Attempt First Reboot' do
-        apply_reboot_manifest(agent, reboot_manifest, /\[\/first.txt\]\/ensure: created/)
+        apply_reboot_manifest(agent, reboot_manifest, %r{\[\/first.txt\]\/ensure: created})
       end
 
       it 'Resume After Reboot' do
-        apply_reboot_manifest(agent, reboot_manifest, /\[\/second.txt\]\/ensure: created/)
+        apply_reboot_manifest(agent, reboot_manifest, %r{\[\/second.txt\]\/ensure: created})
       end
 
       it 'Verify Manifest is Finished' do
@@ -87,11 +86,11 @@ describe 'Puppet Resume after Reboot' do
   windows_agents.each do |agent|
     context "on #{agent}" do
       it 'Attempt First Reboot' do
-        apply_reboot_manifest(agent, windows_reboot_manifest, /\[c:\/first.txt\]\/ensure: created/)
+        apply_reboot_manifest(agent, windows_reboot_manifest, %r{\[c:\/first.txt\]\/ensure: created})
       end
 
       it 'Resume After Reboot' do
-        apply_reboot_manifest(agent, windows_reboot_manifest, /\[c:\/second.txt\]\/ensure: created/)
+        apply_reboot_manifest(agent, windows_reboot_manifest, %r{\[c:\/second.txt\]\/ensure: created})
       end
 
       it 'Verify Manifest is Finished' do

--- a/spec/acceptance/reboot_skip_spec.rb
+++ b/spec/acceptance/reboot_skip_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper_acceptance'
 
 describe 'Reboot Skip' do
-
   def apply_reboot_manifest(agent, reboot_manifest)
-    apply_manifest_on(agent, reboot_manifest, {:debug => true}) do |result|
-      assert_match /Transaction canceled, skipping/,
+    apply_manifest_on(agent, reboot_manifest, debug: true) do |result|
+      assert_match %r{Transaction canceled, skipping},
                    result.stdout, 'Expected resource was not skipped'
     end
     retry_shutdown_abort(agent)
   end
 
-  let(:reboot_manifest){
+  let(:reboot_manifest) do
     <<-MANIFEST
       notify { 'step_1':
       } ~>
@@ -19,7 +18,7 @@ describe 'Reboot Skip' do
       notify { 'step_2':
       }
     MANIFEST
-  }
+  end
 
   posix_agents.each do |agent|
     context "on #{agent}" do

--- a/spec/acceptance/reboot_timeout_spec.rb
+++ b/spec/acceptance/reboot_timeout_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Custom Timeout' do
-
-  let(:reboot_manifest) {
+  let(:reboot_manifest) do
     <<-MANIFEST
       notify { 'step_1':
       }
@@ -12,17 +11,17 @@ describe 'Custom Timeout' do
         timeout => 120,
       }
     MANIFEST
-  }
+  end
 
   posix_agents.each do |agent|
     context "on #{agent}" do
       it 'Reboot Immediately with a Custom Timeout' do
-        apply_manifest_on agent, reboot_manifest, {:debug => true} do |result|
-          if fact_on(agent, 'kernel') == 'SunOS'
-            expected_command = /shutdown -y -i 6 -g 120/
-          else
-            expected_command = /shutdown -r \+2/
-          end
+        apply_manifest_on agent, reboot_manifest, debug: true do |result|
+          expected_command = if fact_on(agent, 'kernel') == 'SunOS'
+                               %r{shutdown -y -i 6 -g 120}
+                             else
+                               %r{shutdown -r \+2}
+                             end
 
           assert_match expected_command,
                        result.stdout, 'Expected reboot timeout is incorrect'
@@ -36,8 +35,8 @@ describe 'Custom Timeout' do
   windows_agents.each do |agent|
     context "on #{agent}" do
       it 'Reboot Immediately with a Custom Timeout' do
-        apply_manifest_on agent, reboot_manifest, {:debug => true} do |result|
-          assert_match /shutdown\.exe \/r \/t 120 \/d p:4:1/,
+        apply_manifest_on agent, reboot_manifest, debug: true do |result|
+          assert_match %r{shutdown\.exe \/r \/t 120 \/d p:4:1},
                        result.stdout, 'Expected reboot timeout is incorrect'
         end
         sleep 61
@@ -46,4 +45,3 @@ describe 'Custom Timeout' do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,5 +11,5 @@ end
 # We need this because the RAL uses 'should' as a method.  This
 # allows us the same behaviour but with a different method name.
 class Object
-  alias :must :should
+  alias must should
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,8 +8,8 @@ install_module_dependencies_on(hosts)
 
 test_name 'Installing Puppet Modules' do
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  staging = { :module_name => 'puppetlabs-reboot' }
-  local = { :module_name => 'reboot', :source => proj_root }
+  staging = { module_name: 'puppetlabs-reboot' }
+  local = { module_name: 'reboot', source: proj_root }
 
   hosts.each do |host|
     step 'Install Reboot Module Dependencies'
@@ -24,28 +24,28 @@ end
 
 require 'rubygems' # this is necessary for ruby 1.8
 require 'puppet/version'
-WINDOWS_SHUTDOWN_ABORT = 'cmd /c shutdown /a'
-#Some versions of ruby and puppet improperly report exit codes
+WINDOWS_SHUTDOWN_ABORT = 'cmd /c shutdown /a'.freeze
+# Some versions of ruby and puppet improperly report exit codes
 # due to a ruby bug the correct error code 1116, is returned modulo 256 = 92
-WINDOWS_SHUTDOWN_NOT_IN_PROGRESS = [1116, 1116 % 256]
+WINDOWS_SHUTDOWN_NOT_IN_PROGRESS = [1116, 1116 % 256].freeze
 
 def shutdown_pid(agent)
   # code to get ps command taken from Facter 2.x implementation
   # as Facter 3.x is dropping the ps fact
   ps = case fact_on(agent, 'operatingsystem')
-         when 'OpenWrt'
-           'ps www'
-         when 'FreeBSD', 'NetBSD', 'OpenBSD', 'Darwin', 'DragonFly'
-           'ps auxwww'
-         else
-           'ps -ef'
+       when 'OpenWrt'
+         'ps www'
+       when 'FreeBSD', 'NetBSD', 'OpenBSD', 'Darwin', 'DragonFly'
+         'ps auxwww'
+       else
+         'ps -ef'
        end
   # code to isolate PID adapted from Puppet service base provider
-  on(agent, ps).stdout.each_line { |line|
-    if line.match(/shutdown/)
-      return line.sub(/^\s+/, '').split(/\s+/)[1]
+  on(agent, ps).stdout.each_line do |line|
+    if line =~ %r{shutdown}
+      return line.sub(%r{^\s+}, '').split(%r{\s+})[1]
     end
-  }
+  end
   nil
 end
 
@@ -53,11 +53,11 @@ def ensure_shutdown_not_scheduled(agent)
   sleep 5
 
   if windows_agents.include?(agent)
-    on agent, WINDOWS_SHUTDOWN_ABORT, {:acceptable_exit_codes => WINDOWS_SHUTDOWN_NOT_IN_PROGRESS}
+    on agent, WINDOWS_SHUTDOWN_ABORT, acceptable_exit_codes: WINDOWS_SHUTDOWN_NOT_IN_PROGRESS
   else
     pid = shutdown_pid(agent)
     if pid
-      on(agent, "kill #{pid}", :acceptable_exit_codes => [0])
+      on(agent, "kill #{pid}", acceptable_exit_codes: [0])
       raise CommandFailure, "Host '#{agent}' had unexpected scheduled shutdown with PID #{pid}."
     end
   end
@@ -67,10 +67,10 @@ def retry_shutdown_abort(agent, max_retries = 6)
   i = 0
   while i < max_retries
     if windows_agents.include?(agent)
-      result = on(agent, WINDOWS_SHUTDOWN_ABORT, :acceptable_exit_codes => [0, WINDOWS_SHUTDOWN_NOT_IN_PROGRESS].flatten)
+      result = on(agent, WINDOWS_SHUTDOWN_ABORT, acceptable_exit_codes: [0, WINDOWS_SHUTDOWN_NOT_IN_PROGRESS].flatten)
     else
       pid = shutdown_pid(agent)
-      result = on(agent, "kill #{pid}", :acceptable_exit_codes => [0]) if pid
+      result = on(agent, "kill #{pid}", acceptable_exit_codes: [0]) if pid
     end
     break if result.exit_code == 0
 
@@ -79,9 +79,7 @@ def retry_shutdown_abort(agent, max_retries = 6)
     i += 1
   end
 
-  if i == max_retries
-    fail_test "Failed to abort shutdown on #{agent}"
-  end
+  fail_test "Failed to abort shutdown on #{agent}" if i == max_retries
 end
 
 def windows_agents
@@ -89,7 +87,7 @@ def windows_agents
 end
 
 def posix_agents
-  agents.select { |agent| !agent['platform'].include?('windows') }
+  agents.reject { |agent| agent['platform'].include?('windows') }
 end
 
 def linux_agents

--- a/spec/unit/provider/reboot/linux_spec.rb
+++ b/spec/unit/provider/reboot/linux_spec.rb
@@ -1,58 +1,58 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/type'
 require 'puppet/provider/reboot/linux'
 require 'puppet/provider/reboot/posix'
 
 describe Puppet::Type.type(:reboot).provider(:linux) do
-  let(:resource) { Puppet::Type.type(:reboot).new(:provider => :linux, :name => "linux_reboot") }
+  let(:resource) { Puppet::Type.type(:reboot).new(provider: :linux, name: 'linux_reboot') }
   let(:provider) { resource.provider }
 
-  it "should be an instance of Puppet::Type::Reboot::ProviderLinux" do
+  it 'is an instance of Puppet::Type::Reboot::ProviderLinux' do
     provider.must be_an_instance_of Puppet::Type::Reboot::ProviderLinux
   end
 
-  it "should be a kind of Puppet::Type::Reboot::ProviderPosix" do
+  it 'is a kind of Puppet::Type::Reboot::ProviderPosix' do
     provider.must be_a_kind_of Puppet::Type::Reboot::ProviderPosix
   end
 
   context '#initialize' do
-    it 'should issue a deprecation warning' do
+    it 'issues a deprecation warning' do
       Puppet.expects(:deprecation_warning).with("The 'linux' reboot provider is deprecated and will be removed; use 'posix' instead.")
 
-      Puppet::Type.type(:reboot).new(:provider => :linux, :name => "linux_reboot")
+      Puppet::Type.type(:reboot).new(provider: :linux, name: 'linux_reboot')
     end
   end
 
-  context "self.instances" do
-    it "should return an empty array" do
+  context 'self.instances' do
+    it 'returns an empty array' do
       provider.class.instances.should == []
     end
   end
 
-  context "when checking if the `when` property is insync" do
-    it "is absent by default" do
+  context 'when checking if the `when` property is insync' do
+    it 'is absent by default' do
       expect(provider.when).to eq(:absent)
     end
 
-    it "should not reboot when setting the `when` property to refreshed" do
+    it 'does not reboot when setting the `when` property to refreshed' do
       provider.expects(:reboot).never
 
       provider.when = :refreshed
     end
   end
 
-  context "when a reboot is triggered", :if => Puppet::Util.which('shutdown') do
+  context 'when a reboot is triggered', if: Puppet::Util.which('shutdown') do
     before :each do
       provider.expects(:async_shutdown).with(includes('shutdown')).at_most_once
+      Facter.stubs(:value).with(:kernel).returns('Linux')
     end
 
-    it "stops the application by default" do
+    it 'stops the application by default' do
       Puppet::Application.expects(:stop!)
       provider.reboot
     end
 
-    it "cancels the rest of the catalog transaction if apply is set to immediately" do
+    it 'cancels the rest of the catalog transaction if apply is set to immediately' do
       resource[:apply] = :immediately
       Puppet::Application.expects(:stop!)
       provider.reboot
@@ -64,29 +64,25 @@ describe Puppet::Type.type(:reboot).provider(:linux) do
       provider.reboot
     end
 
-    before :each do
-      Facter.stubs(:value).with(:kernel).returns('Linux')
-    end
-
-    it "includes the restart flag" do
+    it 'includes the restart flag' do
       provider.expects(:async_shutdown).with(includes('-r'))
       provider.reboot
     end
 
-    it "includes a timeout in the future" do
+    it 'includes a timeout in the future' do
       provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
       provider.reboot
     end
 
-    it "rounds up and provides a warning if the timeout is not a multiple of 60" do
+    it 'rounds up and provides a warning if the timeout is not a multiple of 60' do
       resource[:timeout] = 61
       Puppet.expects(:warning).with(includes('rounding'))
       provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
       provider.reboot
     end
 
-    it "includes the quoted reboot message" do
-      resource[:message] = "triggering a reboot"
+    it 'includes the quoted reboot message' do
+      resource[:message] = 'triggering a reboot'
       provider.expects(:async_shutdown).with(includes('"triggering a reboot"'))
       provider.reboot
     end

--- a/spec/unit/provider/reboot/posix_spec.rb
+++ b/spec/unit/provider/reboot/posix_spec.rb
@@ -1,45 +1,44 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/type'
 require 'puppet/provider/reboot/posix'
 
 describe Puppet::Type.type(:reboot).provider(:posix) do
-  let(:resource) { Puppet::Type.type(:reboot).new(:provider => :posix, :name => "posix_reboot") }
+  let(:resource) { Puppet::Type.type(:reboot).new(provider: :posix, name: 'posix_reboot') }
   let(:provider) { resource.provider }
 
-  it "should be an instance of Puppet::Type::Reboot::ProviderPosix" do
+  it 'is an instance of Puppet::Type::Reboot::ProviderPosix' do
     provider.must be_an_instance_of Puppet::Type::Reboot::ProviderPosix
   end
 
-  context "self.instances" do
-    it "should return an empty array" do
+  context 'self.instances' do
+    it 'returns an empty array' do
       provider.class.instances.should == []
     end
   end
 
-  context "when checking if the `when` property is insync" do
-    it "is absent by default" do
+  context 'when checking if the `when` property is insync' do
+    it 'is absent by default' do
       expect(provider.when).to eq(:absent)
     end
 
-    it "should not reboot when setting the `when` property to refreshed" do
+    it 'does not reboot when setting the `when` property to refreshed' do
       provider.expects(:reboot).never
 
       provider.when = :refreshed
     end
   end
 
-  context "when a reboot is triggered", :if => Puppet::Util.which('shutdown') do
+  context 'when a reboot is triggered', if: Puppet::Util.which('shutdown') do
     before :each do
       provider.expects(:async_shutdown).with(includes('shutdown')).at_most_once
     end
 
-    it "stops the application by default" do
+    it 'stops the application by default' do
       Puppet::Application.expects(:stop!)
       provider.reboot
     end
 
-    it "cancels the rest of the catalog transaction if apply is set to immediately" do
+    it 'cancels the rest of the catalog transaction if apply is set to immediately' do
       resource[:apply] = :immediately
       Puppet::Application.expects(:stop!)
       provider.reboot
@@ -51,27 +50,27 @@ describe Puppet::Type.type(:reboot).provider(:posix) do
       provider.reboot
     end
 
-    context "on Solaris" do
+    context 'on Solaris' do
       before :each do
         Facter.stubs(:value).with(:kernel).returns('SunOS')
       end
 
-      it "includes the pre-confirmation flag" do
+      it 'includes the pre-confirmation flag' do
         provider.expects(:async_shutdown).with(includes('-y'))
         provider.reboot
       end
 
-      it "includes the init-state 6 flag" do
+      it 'includes the init-state 6 flag' do
         provider.expects(:async_shutdown).with(includes('-i 6'))
         provider.reboot
       end
 
-      it "includes a timeout in the future" do
+      it 'includes a timeout in the future' do
         provider.expects(:async_shutdown).with(includes("-g #{resource[:timeout].to_i}"))
         provider.reboot
       end
 
-      it "accepts timeouts that are not multiples of 60" do
+      it 'accepts timeouts that are not multiples of 60' do
         resource[:timeout] = 61
         Puppet.expects(:warning).with(includes('rounding')).never
         provider.expects(:async_shutdown).with(includes("-g #{resource[:timeout].to_i}"))
@@ -79,22 +78,22 @@ describe Puppet::Type.type(:reboot).provider(:posix) do
       end
     end
 
-    context "on other systems" do
+    context 'on other systems' do
       before :each do
         Facter.stubs(:value).with(:kernel).returns('Linux')
       end
 
-      it "includes the restart flag" do
+      it 'includes the restart flag' do
         provider.expects(:async_shutdown).with(includes('-r'))
         provider.reboot
       end
 
-      it "includes a timeout in the future" do
+      it 'includes a timeout in the future' do
         provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
         provider.reboot
       end
 
-      it "rounds up and provides a warning if the timeout is not a multiple of 60" do
+      it 'rounds up and provides a warning if the timeout is not a multiple of 60' do
         resource[:timeout] = 61
         Puppet.expects(:warning).with(includes('rounding'))
         provider.expects(:async_shutdown).with(includes("+#{(resource[:timeout].to_i / 60.0).ceil}"))
@@ -102,8 +101,8 @@ describe Puppet::Type.type(:reboot).provider(:posix) do
       end
     end
 
-    it "includes the quoted reboot message" do
-      resource[:message] = "triggering a reboot"
+    it 'includes the quoted reboot message' do
+      resource[:message] = 'triggering a reboot'
       provider.expects(:async_shutdown).with(includes('"triggering a reboot"'))
       provider.reboot
     end

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -1,68 +1,68 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/type'
 require 'puppet/provider/reboot/windows'
 
-describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.microsoft_windows? do
-  let(:resource) { Puppet::Type.type(:reboot).new(:provider => :windows, :name => "windows_reboot") }
+describe Puppet::Type.type(:reboot).provider(:windows), if: Puppet.features.microsoft_windows? do
+  let(:resource) { Puppet::Type.type(:reboot).new(provider: :windows, name: 'windows_reboot') }
   let(:provider) { resource.provider }
   let(:native_path)     { "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe" }
   let(:redirected_path) { "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe" }
+  let(:shutdown_not_found_error) { 'The shutdown.exe command was not found. On Windows 2003 x64 hotfix 942589 must be installed to access the 64-bit version of shutdown.exe from 32-bit version of ruby.exe.' } # rubocop:disable Metrics/LineLength
 
   before :each do
     resource.class.rebooting = false
   end
 
-  it "should be an instance of Puppet::Type::Reboot::ProviderWindows" do
+  it 'is an instance of Puppet::Type::Reboot::ProviderWindows' do
     provider.must be_an_instance_of Puppet::Type::Reboot::ProviderWindows
   end
 
-  context "self.instances" do
-    it "should return an empty array" do
+  context 'self.instances' do
+    it 'returns an empty array' do
       provider.class.instances.should == []
     end
   end
 
-  context "when resolving the shutdown command" do
-    it "should try to disable file system redirection" do
-      File.expects(:exists?).with(native_path).returns(true)
+  context 'when resolving the shutdown command' do
+    it 'tries to disable file system redirection' do
+      File.expects(:exist?).with(native_path).returns(true)
       expect(provider.class.shutdown_command).to eq(native_path)
     end
 
-    it "should fall back to system32" do
-      File.expects(:exists?).with(native_path).returns(false)
-      File.expects(:exists?).with(redirected_path).returns(true)
+    it 'falls back to system32' do
+      File.expects(:exist?).with(native_path).returns(false)
+      File.expects(:exist?).with(redirected_path).returns(true)
       expect(provider.class.shutdown_command).to eq(redirected_path)
     end
 
-    it "should use 'shutdown.exe'" do
-      File.expects(:exists?).with(native_path).returns(false)
-      File.expects(:exists?).with(redirected_path).returns(false)
+    it "uses 'shutdown.exe'" do
+      File.expects(:exist?).with(native_path).returns(false)
+      File.expects(:exist?).with(redirected_path).returns(false)
       expect(provider.class.shutdown_command).to eq('shutdown.exe')
     end
 
-    it "should raise an error if shutdown.exe cannot be found" do
+    it 'raises an error if shutdown.exe cannot be found' do
       provider.expects(:command).with(:shutdown).returns(nil)
       provider.expects(:async_shutdown).never
 
       expect {
         provider.reboot
-      }.to raise_error(ArgumentError, 'The shutdown.exe command was not found. On Windows 2003 x64 hotfix 942589 must be installed to access the 64-bit version of shutdown.exe from 32-bit version of ruby.exe.')
+      }.to raise_error(ArgumentError, shutdown_not_found_error)
     end
   end
 
-  context "when checking if the `when` property is insync" do
-    it "is absent by default" do
+  context 'when checking if the `when` property is insync' do
+    it 'is absent by default' do
       expect(provider.when).to eq(:absent)
     end
 
-    it "should not reboot when setting the `when` property to refreshed" do
+    it 'does not reboot when setting the `when` property to refreshed' do
       provider.expects(:reboot).never
 
       provider.when = :refreshed
     end
 
-    it "issues a shutdown command when a reboot is pending" do
+    it 'issues a shutdown command when a reboot is pending' do
       resource[:when] = :pending
 
       provider.expects(:command).with(:shutdown).returns(native_path)
@@ -72,18 +72,18 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
     end
   end
 
-  context "when a reboot is triggered", :if => Puppet::Util.which('shutdown.exe') do
+  context 'when a reboot is triggered', if: Puppet::Util.which('shutdown.exe') do
     before :each do
       provider.expects(:async_shutdown).with(includes('shutdown.exe')).at_most_once
     end
 
-    it "stops the application by default" do
+    it 'stops the application by default' do
       Puppet::Application.expects(:stop!)
       provider.reboot
     end
 
-    context "when apply is set to finished and when is set to pending" do
-      it "throws an unsupported warning" do
+    context 'when apply is set to finished and when is set to pending' do
+      it 'throws an unsupported warning' do
         resource[:when] = :pending
         resource[:apply] = :finished
         Puppet.expects(:warning).with(includes('The combination'))
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
       end
     end
 
-    it "cancels the rest of the catalog transaction if apply is set to immediately" do
+    it 'cancels the rest of the catalog transaction if apply is set to immediately' do
       resource[:apply] = :immediately
       Puppet::Application.expects(:stop!)
       provider.reboot
@@ -103,47 +103,47 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
       provider.reboot
     end
 
-    it "does not include the interactive flag" do
+    it 'does not include the interactive flag' do
       provider.expects(:async_shutdown).with(Not(includes('/i')))
       provider.reboot
     end
 
-    it "includes the restart flag" do
+    it 'includes the restart flag' do
       provider.expects(:async_shutdown).with(includes('/r'))
       provider.reboot
     end
 
-    it "includes a timeout in the future" do
+    it 'includes a timeout in the future' do
       provider.expects(:async_shutdown).with(includes("/t #{resource[:timeout]}"))
       provider.reboot
     end
 
-    it "includes the shutdown reason as Application Maintenance (Planned)" do
-      provider.expects(:async_shutdown).with(includes("/d p:4:1"))
+    it 'includes the shutdown reason as Application Maintenance (Planned)' do
+      provider.expects(:async_shutdown).with(includes('/d p:4:1'))
       provider.reboot
     end
 
-    it "includes the quoted reboot message" do
-      resource[:message] = "triggering a reboot"
+    it 'includes the quoted reboot message' do
+      resource[:message] = 'triggering a reboot'
       provider.expects(:async_shutdown).with(includes('"triggering a reboot"'))
       provider.reboot
     end
 
-    context "multiple triggered reboots" do
-      let(:resource2) { Puppet::Type.type(:reboot).new(:provider => :windows, :name => "windows_reboot2") }
+    context 'multiple triggered reboots' do
+      let(:resource2) { Puppet::Type.type(:reboot).new(provider: :windows, name: 'windows_reboot2') }
       let(:provider2) { resource2.provider }
 
-      context "where the second resource has when set to pending" do
+      context 'where the second resource has when set to pending' do
         before :each do
           resource2[:when] = :pending
         end
 
-        context "where the first resource has apply set to finished" do
+        context 'where the first resource has apply set to finished' do
           before :each do
             resource[:apply] = :finished
           end
 
-          it "should only reboot once" do
+          it 'onlies reboot once' do
             resource[:when] = :refreshed
             provider.expects(:reboot)
 
@@ -154,7 +154,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
             provider2.when = :pending
           end
 
-          it "should only reboot once when the first resource has when set to pending" do
+          it 'onlies reboot once when the first resource has when set to pending' do
             # this isn't supported but no harm testing that it doesn't blow up
             resource[:when] = :pending
             provider.expects(:reboot)
@@ -169,7 +169,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
     end
   end
 
-  context "when detecting if a reboot is pending" do
+  context 'when detecting if a reboot is pending' do
     def expects_registry_key(path)
       Win32::Registry::HKEY_LOCAL_MACHINE.expects(:open).with(path, anything)
     end
@@ -237,7 +237,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
       let(:name) { 'PendingFileRenameOperations' }
 
       it 'reboots if the value exists and is non-empty' do
-        expects_registry_value(path, name, ['C:/from','C:/to'])
+        expects_registry_value(path, name, ['C:/from', 'C:/to'])
 
         provider.should be_pending_file_rename_operations
       end
@@ -472,7 +472,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
       it 'reboots when reboot_required is set to true' do
         provider.reboot_required = true
 
-        expect(provider.reboot_pending?).to be (true)
+        expect(provider.reboot_pending?).to be true
       end
 
       it 'does not reboot when reboot_required is set to false' do
@@ -488,7 +488,7 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         provider.expects(:pending_dsc_reboot?).returns(false)
         provider.expects(:pending_ccm_reboot?).returns(false)
 
-        expect(provider.reboot_pending?).to be_falsey
+        expect(provider).not_to be_reboot_pending
       end
     end
 
@@ -497,16 +497,16 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         resource[:onlyif] = [:pending_dsc_reboot]
         resource[:when] = :pending
 
-        #provider.expects(:component_based_servicing?).returns(true)
-        #provider.expects(:windows_auto_update?).returns(true)
-        #provider.expects(:pending_file_rename_operations?).returns(true)
-        #provider.expects(:package_installer?).returns(true)
-        #provider.expects(:package_installer_syswow64?).returns(true)
-        #provider.expects(:pending_computer_rename?).returns(true)
+        # provider.expects(:component_based_servicing?).returns(true)
+        # provider.expects(:windows_auto_update?).returns(true)
+        # provider.expects(:pending_file_rename_operations?).returns(true)
+        # provider.expects(:package_installer?).returns(true)
+        # provider.expects(:package_installer_syswow64?).returns(true)
+        # provider.expects(:pending_computer_rename?).returns(true)
         provider.expects(:pending_dsc_reboot?).returns(false)
-        #provider.expects(:pending_ccm_reboot?).returns(true)
+        # provider.expects(:pending_ccm_reboot?).returns(true)
 
-        expect(provider.reboot_pending?).to be_falsey
+        expect(provider).not_to be_reboot_pending
       end
     end
 
@@ -521,12 +521,11 @@ describe Puppet::Type.type(:reboot).provider(:windows), :if => Puppet.features.m
         provider.expects(:package_installer?).returns(false)
         provider.expects(:package_installer_syswow64?).returns(false)
         provider.expects(:pending_computer_rename?).returns(false)
-        #provider.expects(:pending_dsc_reboot?).returns(true)
+        # provider.expects(:pending_dsc_reboot?).returns(true)
         provider.expects(:pending_ccm_reboot?).returns(false)
 
-        expect(provider.reboot_pending?).to be_falsey
+        expect(provider).not_to be_reboot_pending
       end
     end
   end
-
 end

--- a/spec/unit/type/reboot_spec.rb
+++ b/spec/unit/type/reboot_spec.rb
@@ -1,10 +1,9 @@
-#! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/type'
 require 'puppet/type/reboot'
 
 describe Puppet::Type.type(:reboot) do
-  let(:resource) { Puppet::Type.type(:reboot).new(:name => "reboot") }
+  let(:resource) { Puppet::Type.type(:reboot).new(name: 'reboot') }
   let(:provider) { Puppet::Provider.new(resource) }
 
   before :each do
@@ -12,19 +11,19 @@ describe Puppet::Type.type(:reboot) do
     resource.class.rebooting = false
   end
 
-  it "should be an instance of Puppet::Type::Reboot" do
+  it 'is an instance of Puppet::Type::Reboot' do
     resource.must be_an_instance_of Puppet::Type::Reboot
   end
 
-  context "when refreshed" do
-    it "should only reboot if the `when` parameter is `refreshed`" do
+  context 'when refreshed' do
+    it 'onlies reboot if the `when` parameter is `refreshed`' do
       resource[:when] = :refreshed
       resource.provider.expects(:reboot)
 
       resource.refresh
     end
 
-    it "should not reboot if the `when` parameter is `pending`" do
+    it 'does not reboot if the `when` parameter is `pending`' do
       resource.provider.expects(:satisfies?).with([:manages_reboot_pending]).returns(true)
       resource.provider.expects(:reboot).never
       resource[:when] = :pending
@@ -33,165 +32,165 @@ describe Puppet::Type.type(:reboot) do
     end
   end
 
-  context "parameter :when" do
-    it "should default to :refreshed" do
+  context 'parameter :when' do
+    it 'defaults to :refreshed' do
       resource[:when].must == :refreshed
     end
 
-    it "should accept :pending" do
+    it 'accepts :pending' do
       resource.provider.expects(:satisfies?).with([:manages_reboot_pending]).returns(true)
 
       resource[:when] = :pending
     end
 
-    it "should reject other values" do
+    it 'rejects other values' do
       expect {
         resource[:when] = :whenever
-      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are refreshed/)
+      }.to raise_error(Puppet::ResourceError, %r{Invalid value :whenever. Valid values are refreshed})
     end
   end
 
-  context "parameter :apply" do
-    it "should default to :immediately" do
+  context 'parameter :apply' do
+    it 'defaults to :immediately' do
       resource[:apply].must == :immediately
     end
 
-    it "should accept :finished" do
+    it 'accepts :finished' do
       resource[:apply] = :finished
     end
 
-    it "should reject other values" do
+    it 'rejects other values' do
       expect {
         resource[:apply] = :whenever
-      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are immediately/)
+      }.to raise_error(Puppet::ResourceError, %r{Invalid value :whenever. Valid values are immediately})
     end
   end
 
-  context "parameter :message" do
-    it "should default to \"Puppet is rebooting the computer\"" do
-      resource[:message].must == "Puppet is rebooting the computer"
+  context 'parameter :message' do
+    it 'defaults to "Puppet is rebooting the computer"' do
+      resource[:message].must == 'Puppet is rebooting the computer'
     end
 
-    it "should accept a custom message" do
-      resource[:message] = "This is a different message"
+    it 'accepts a custom message' do
+      resource[:message] = 'This is a different message'
     end
 
-    it "should reject an empty value" do
+    it 'rejects an empty value' do
       expect {
-        resource[:message] = ""
-      }.to raise_error(Puppet::ResourceError, /A non-empty message must be specified./)
+        resource[:message] = ''
+      }.to raise_error(Puppet::ResourceError, %r{A non-empty message must be specified.})
     end
 
-    it "should accept a 8000 character message" do
+    it 'accepts a 8000 character message' do
       resource[:message] = 'a' * 8000
     end
 
-    it "should reject a 8001 character message" do
+    it 'rejects a 8001 character message' do
       expect {
         resource[:message] = 'a' * 8001
-      }.to raise_error(Puppet::ResourceError, /The given message must not exceed 8000 characters./)
+      }.to raise_error(Puppet::ResourceError, %r{The given message must not exceed 8000 characters.})
     end
 
-    it "should be logged on reboot" do
-      resource[:message] = "Custom message"
-      logmessage = "Scheduling system reboot with message: \"Custom message\""
+    it 'is logged on reboot' do
+      resource[:message] = 'Custom message'
+      logmessage = 'Scheduling system reboot with message: "Custom message"'
       Puppet.expects(:notice).with(logmessage)
       resource.provider.expects(:reboot)
       resource.refresh
     end
   end
 
-  context "parameter :timeout" do
-    it "should default :timeout to 60 seconds" do
+  context 'parameter :timeout' do
+    it 'defaults :timeout to 60 seconds' do
       resource[:timeout].must == 60
     end
 
-    it "should accept 30 minute timeout" do
+    it 'accepts 30 minute timeout' do
       resource[:timeout] = 30 * 60
     end
 
-    ["later", :later, {}, [], true].each do |timeout|
+    ['later', :later, {}, [], true].each do |timeout|
       it "should reject a non-integer (#{timeout.class}) value" do
         expect {
           resource[:timeout] = timeout
-        }.to raise_error(Puppet::ResourceError, /The timeout must be an integer/)
+        }.to raise_error(Puppet::ResourceError, %r{The timeout must be an integer})
       end
     end
   end
 
-  context "parameter :onlyif" do
-    it "should default :onlyif to nil" do
-      resource[:onlyif].must == nil
+  context 'parameter :onlyif' do
+    it 'defaults :onlyif to nil' do
+      resource[:onlyif].must.nil?
     end
 
-    it "should accept package_installer reason" do
+    it 'accepts package_installer reason array' do
       resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
       resource[:onlyif] = [:package_installer]
     end
 
-    it "should accept package_installer reason" do
+    it 'accepts package_installer reason' do
       resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
       resource[:onlyif] = :package_installer
     end
 
-    it "shouldn't accept an empty list" do
+    it 'does not accept an empty list' do
       expect {
         resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
         resource[:onlyif] = []
-      }.to raise_error(Puppet::ResourceError, /There must be at least one element in the list/)
+      }.to raise_error(Puppet::ResourceError, %r{There must be at least one element in the list})
     end
 
-    ["pks_install", :pkg_install, {}, true].each do |reason|
+    ['pks_install', :pkg_install, {}, true].each do |reason|
       it "should reject invalid reasons (#{reason})" do
         expect {
           resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
           resource[:onlyif] = reason
-        }.to raise_error(Puppet::ResourceError, /value must be one of/)
+        }.to raise_error(Puppet::ResourceError, %r{value must be one of})
       end
     end
   end
 
-  context "parameter :unless" do
-    it "should default :timeout to nil" do
-      resource[:unless].must == nil
+  context 'parameter :unless' do
+    it 'defaults :timeout to nil' do
+      resource[:unless].must.nil?
     end
 
-    it "should accept package_installer reason" do
+    it 'accepts package_installer reason array' do
       resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
       resource[:unless] = [:package_installer]
     end
 
-    it "should accept package_installer reason" do
+    it 'accepts package_installer reason' do
       resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
       resource[:unless] = :package_installer
     end
 
-    it "shouldn't accept an empty list" do
+    it 'does not accept an empty list' do
       expect {
         resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
         resource[:unless] = []
-      }.to raise_error(Puppet::ResourceError, /There must be at least one element in the list/)
+      }.to raise_error(Puppet::ResourceError, %r{There must be at least one element in the list})
     end
 
-    ["pks_install", :pkg_install, {}, true].each do |reason|
+    ['pks_install', :pkg_install, {}, true].each do |reason|
       it "should reject invalid reasons (#{reason})" do
         expect {
           resource.provider.class.expects(:satisfies?).with(:manages_reboot_pending).returns(true)
           resource[:unless] = reason
-        }.to raise_error(Puppet::ResourceError, /value must be one of/)
+        }.to raise_error(Puppet::ResourceError, %r{value must be one of})
       end
     end
   end
 
-  context "multiple reboot resources" do
-    let(:resource2) { Puppet::Type.type(:reboot).new(:name => "reboot2") }
+  context 'multiple reboot resources' do
+    let(:resource2) { Puppet::Type.type(:reboot).new(name: 'reboot2') }
     let(:provider2) { Puppet::Provider.new(resource2) }
 
     before :each do
       resource2.provider = provider2
     end
 
-    it "should only reboot once even if more than one triggers" do
+    it 'onlies reboot once even if more than one triggers' do
       resource[:apply] = :finished
       resource[:when] = :refreshed
       resource.provider.expects(:reboot)


### PR DESCRIPTION
Previously rubocop was not enforced on ruby code.  This commit fixes the
existing rubocop violations in preparation for enabling rubocop in CI.  This
commit uses the rubocop configuration which was deployed in PDK template
1.3.2-0-g07678c8.