### PR TITLE
(maint) Fix typo in for travis yaml file

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,7 @@ spec/spec_helper.rb:
 appveyor.yml:
   test_script:
     - 'bundle exec rspec spec/unit -fd -b'
-travis.yml:
+.travis.yml:
   extras:
     - rvm: 2.1.9
       script: bundle exec rake rubocop


### PR DESCRIPTION
Without this commit, modsync will fail to parse this module as the name of the
travis file is actually `.travis.yml`.
