### PR TITLE
(MODULES-6745) Add testmode to tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,12 @@
 ---
 Rakefile:
   unmanaged: true
+Gemfile:
+  optional:
+    ':system_tests':
+      - gem: beaker-testmode_switcher
+        version: '~> 0.4'
+      - gem: master_manipulator
 spec/spec_helper.rb:
   unmanaged: true
 appveyor.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -54,11 +54,13 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem "beaker-testmode_switcher", '~> 0.4',                                      :require => false
+  gem 'master_manipulator',                                                      :require => false
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 

--- a/spec/acceptance/reboot_finished_spec.rb
+++ b/spec/acceptance/reboot_finished_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'Reboot when Finished' do
   def apply_reboot_manifest(agent, reboot_manifest)
-    apply_manifest_on agent, reboot_manifest do |result|
+    execute_manifest_on(agent, reboot_manifest) do |result|
       assert_match %r{defined 'message' as 'step_2'},
                    result.stdout, 'Expected step was not finished before reboot'
     end

--- a/spec/acceptance/reboot_immediate_spec.rb
+++ b/spec/acceptance/reboot_immediate_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'Reboot Immediately and Explicit Immediately' do
   def apply_reboot_manifest(agent, reboot_manifest)
-    apply_manifest_on agent, reboot_manifest
+    execute_manifest_on(agent, reboot_manifest)
     retry_shutdown_abort(agent)
   end
 

--- a/spec/acceptance/reboot_message.spec.rb
+++ b/spec/acceptance/reboot_message.spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'Custom Message' do
   def apply_reboot_manifest(agent, reboot_manifest)
-    apply_manifest_on agent, reboot_manifest, debug: true do |result|
+    execute_manifest_on(agent, reboot_manifest, debug: true) do |result|
       expected_command = if fact_on(agent, 'kernel') == 'SunOS'
                            %r{shutdown -y -i 6 -g 60 \"A different message\"}
                          else

--- a/spec/acceptance/reboot_no_refresh_spec.rb
+++ b/spec/acceptance/reboot_no_refresh_spec.rb
@@ -11,7 +11,7 @@ describe 'No Refresh' do
   posix_agents.each do |agent|
     context "on #{agent}" do
       it 'does not Reboot Computer without Refresh' do
-        apply_manifest_on agent, reboot_manifest
+        execute_manifest_on(agent, reboot_manifest)
         ensure_shutdown_not_scheduled(agent)
       end
     end
@@ -20,7 +20,7 @@ describe 'No Refresh' do
   windows_agents.each do |agent|
     context "on #{agent}" do
       it 'does not Reboot Computer without Refresh' do
-        apply_manifest_on agent, reboot_manifest
+        execute_manifest_on(agent, reboot_manifest)
         ensure_shutdown_not_scheduled(agent)
       end
     end

--- a/spec/acceptance/reboot_pending_spec.rb
+++ b/spec/acceptance/reboot_pending_spec.rb
@@ -35,7 +35,7 @@ describe 'Windows Provider - Pending Reboot' do
       end
 
       it 'Reboot if Pending Reboot Required' do
-        apply_manifest_on agent, reboot_manifest
+        execute_manifest_on(agent, reboot_manifest)
         retry_shutdown_abort(agent)
       end
     end
@@ -50,7 +50,7 @@ describe 'Windows Provider - Pending Reboot' do
         on agent, powershell("\"& { (Get-WmiObject -Class Win32_ComputerSystem).Rename('#{new_name}') }\"")
       end
       it 'Reboot if Pending Reboot Required' do
-        apply_manifest_on agent, reboot_manifest
+        execute_manifest_on(agent, reboot_manifest)
         retry_shutdown_abort(agent)
       end
       if original_name

--- a/spec/acceptance/reboot_resume_spec.rb
+++ b/spec/acceptance/reboot_resume_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'Puppet Resume after Reboot' do
   def apply_reboot_manifest(agent, reboot_manifest, match)
-    apply_manifest_on(agent, reboot_manifest) do |result|
+    execute_manifest_on(agent, reboot_manifest) do |result|
       assert_match match, result.stdout, 'Expected file was not created'
     end
     retry_shutdown_abort(agent)
@@ -77,7 +77,7 @@ describe 'Puppet Resume after Reboot' do
       end
 
       it 'Verify Manifest is Finished' do
-        apply_manifest_on agent, reboot_manifest
+        execute_manifest_on(agent, reboot_manifest)
         ensure_shutdown_not_scheduled(agent)
       end
     end
@@ -94,7 +94,7 @@ describe 'Puppet Resume after Reboot' do
       end
 
       it 'Verify Manifest is Finished' do
-        apply_manifest_on agent, windows_reboot_manifest
+        execute_manifest_on(agent, windows_reboot_manifest)
         ensure_shutdown_not_scheduled(agent)
       end
     end

--- a/spec/acceptance/reboot_skip_spec.rb
+++ b/spec/acceptance/reboot_skip_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'Reboot Skip' do
   def apply_reboot_manifest(agent, reboot_manifest)
-    apply_manifest_on(agent, reboot_manifest, debug: true) do |result|
+    execute_manifest_on(agent, reboot_manifest, debug: true) do |result|
       assert_match %r{Transaction canceled, skipping},
                    result.stdout, 'Expected resource was not skipped'
     end

--- a/spec/acceptance/reboot_timeout_spec.rb
+++ b/spec/acceptance/reboot_timeout_spec.rb
@@ -16,7 +16,7 @@ describe 'Custom Timeout' do
   posix_agents.each do |agent|
     context "on #{agent}" do
       it 'Reboot Immediately with a Custom Timeout' do
-        apply_manifest_on agent, reboot_manifest, debug: true do |result|
+        execute_manifest_on(agent, reboot_manifest, debug: true) do |result|
           expected_command = if fact_on(agent, 'kernel') == 'SunOS'
                                %r{shutdown -y -i 6 -g 120}
                              else
@@ -35,7 +35,7 @@ describe 'Custom Timeout' do
   windows_agents.each do |agent|
     context "on #{agent}" do
       it 'Reboot Immediately with a Custom Timeout' do
-        apply_manifest_on agent, reboot_manifest, debug: true do |result|
+        execute_manifest_on(agent, reboot_manifest, debug: true) do |result|
           assert_match %r{shutdown\.exe \/r \/t 120 \/d p:4:1},
                        result.stdout, 'Expected reboot timeout is incorrect'
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,25 +1,25 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
+require 'beaker/testmode_switcher'
+require 'beaker/testmode_switcher/dsl'
 
 run_puppet_install_helper
 
 install_module_dependencies_on(hosts)
 
-test_name 'Installing Puppet Modules' do
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  staging = { module_name: 'puppetlabs-reboot' }
-  local = { module_name: 'reboot', source: proj_root }
+proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+staging = { module_name: 'puppetlabs-reboot' }
+local = { module_name: 'reboot', source: proj_root }
 
-  hosts.each do |host|
-    step 'Install Reboot Module Dependencies'
-    on(host, puppet('module install puppetlabs-stdlib'))
-    on(host, puppet('module install puppetlabs-registry'))
+hosts.each do |host|
+  # Install Reboot Module Dependencies
+  on(host, puppet('module install puppetlabs-stdlib'))
+  on(host, puppet('module install puppetlabs-registry'))
 
-    step 'Install Reboot Module'
-    # in CI allow install from staging forge, otherwise from local
-    install_dev_puppet_module_on(host, options[:forge_host] ? staging : local)
-  end
+  # Install Reboot Module
+  # in CI allow install from staging forge, otherwise from local
+  install_dev_puppet_module_on(host, options[:forge_host] ? staging : local)
 end
 
 require 'rubygems' # this is necessary for ruby 1.8


### PR DESCRIPTION
This commit adds the necessary entries to the acceptance setup in order
for testmode switcher to work

This commit updates all host execution methods to execute_manifest_on methods.
Where applicable, it changes explicit exitcode calls to catch_failures or
catch_changes.