### PR TITLE
(MODULES-6745) Use testmode-switcher

### DIFF
--- a/spec/acceptance/reboot_pending_spec.rb
+++ b/spec/acceptance/reboot_pending_spec.rb
@@ -24,14 +24,14 @@ describe 'Windows Provider - Pending Reboot' do
       }
       MANIFEST
     windows_agents.each do |agent|
-      apply_manifest_on agent, undo_pending_reboot_manifest
+      execute_manifest_on(agent, undo_pending_reboot_manifest)
     end
   end
 
   windows_agents.each do |agent|
     context "Agent #{agent}" do
       it 'Declare Reboot Required in the Registry' do
-        apply_manifest_on agent, pending_reboot_manifest
+        execute_manifest_on(agent, pending_reboot_manifest)
       end
 
       it 'Reboot if Pending Reboot Required' do

--- a/spec/acceptance/reboot_resume_spec.rb
+++ b/spec/acceptance/reboot_resume_spec.rb
@@ -59,10 +59,10 @@ describe 'Puppet Resume after Reboot' do
       MANIFEST
 
     posix_agents.each do |agent|
-      apply_manifest_on agent, remove_artifacts
+      execute_manifest_on(agent, remove_artifacts)
     end
     windows_agents.each do |agent|
-      apply_manifest_on agent, windows_remove_artifacts
+      execute_manifest_on(agent, windows_remove_artifacts)
     end
   end
 


### PR DESCRIPTION
This change converts the last few calls to the old beaker manifest
helper functions over to the preferred beaker-testmode_switcher helper
functions.