### PR TITLE
(MODULES-7832) Update module for Puppet 6

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -15,6 +15,15 @@ Gemfile:
       - gem: puppet-blacksmith
         version: '~> 3.4'
 
+appveyor.yml:
+  matrix_extras:
+    - PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25
+      CHECK: parallel_spec
+    - PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25-x64
+      CHECK: parallel_spec
+
 # For the moment don't do any rubocop checks.
 .rubocop.yml:
   include_todos: true

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,11 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                                        require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}",                                          require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker-testmode_switcher", '~> 0.4',                                                  require: false
-  gem "master_manipulator",                                                                  require: false
-  gem "puppet-blacksmith", '~> 3.4',                                                         require: false
+  gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "beaker-testmode_switcher", '~> 0.4',           require: false
+  gem "master_manipulator",                           require: false
+  gem "puppet-blacksmith", '~> 3.4',                  require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,14 @@ environment:
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
       CHECK: parallel_spec
+    -
+      PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25
+      CHECK: parallel_spec
+    -
+      PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25-x64
+      CHECK: parallel_spec
 matrix:
   fast_finish: true
 install:

--- a/metadata.json
+++ b/metadata.json
@@ -88,7 +88,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "description": "This module provides a facility for managing reboots across nodes.",


### PR DESCRIPTION
This commit updates the metadata to show support for Puppet 6 and updates the
testing matrix.