### PR TITLE
Use TargetSpec type for wait function

### DIFF
--- a/lib/puppet/functions/reboot/wait.rb
+++ b/lib/puppet/functions/reboot/wait.rb
@@ -5,6 +5,10 @@
 #
 # This has no valid use outside plans!
 Puppet::Functions.create_function(:'reboot::wait') do
+  local_types do
+    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
+  end
+
   # @param targets A TargetSpec containing all targets to wait for
   # @param params Extra parameters defined as a hash, valid keys are:
   #   disconnect_wait, reconnect_wait and retry_interval. All values should be
@@ -12,13 +16,13 @@ Puppet::Functions.create_function(:'reboot::wait') do
   # @example Wait for some very slow nodes to reboot.
   #   reboot::wait($nodes, { 'disconnect_wait' => 120, 'reconnect_wait' => 600 })
   dispatch :wait do
-    required_param 'Variant[Array,Target]', :targets
+    required_param 'TargetOrTargets', :targets
     optional_param 'Hash', :params
   end
 
   def wait(targets, params = { disconnect_wait: 20, reconnect_wait: 120, retry_interval: 1 })
     # Convert to array
-    targets = [targets].flatten
+    targets = call_function('get_targets', targets)
     threads = []
 
     targets.each do |target|

--- a/spec/functions/wait_spec.rb
+++ b/spec/functions/wait_spec.rb
@@ -23,6 +23,8 @@ describe 'reboot::wait', if: bolt_loaded? && tasks_available? do
     let(:target) { Bolt::Target.new('example.puppet.com', 'protocol' => 'pcp') }
 
     it 'will run with a single Target' do
+      Puppet::Pops::Functions::Function.any_instance.stubs(:call_function).with('get_targets', target).returns([target])
+
       # Mock the disconnection and reconnection of a client
       OrchestratorClient.any_instance.expects(:get).with('inventory/example.puppet.com').returns('connected' => true)
       OrchestratorClient.any_instance.expects(:get).with('inventory/example.puppet.com').returns('connected' => false)
@@ -35,6 +37,8 @@ describe 'reboot::wait', if: bolt_loaded? && tasks_available? do
       targets = (1..100).map do |num|
         Bolt::Target.new("example#{num}.puppet.com", 'protocol' => 'pcp')
       end
+
+      Puppet::Pops::Functions::Function.any_instance.stubs(:call_function).with('get_targets', targets).returns(targets)
 
       # Mock the disconnection and reconnection of all clients
       targets.each do |targ|


### PR DESCRIPTION
Rather than Variant[Target, Array]. This makes the function compatible with other ecosystem invocation APIs, such as those of run_command, run_task, etc.