### PR TITLE
Shutdowns!

### DIFF
--- a/spec/unit/task/init_spec.rb
+++ b/spec/unit/task/init_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require_relative '../../../tasks/init'
 
 describe Reboot::Task do # rubocop:disable RSpec/FilePath

--- a/spec/unit/task/init_spec.rb
+++ b/spec/unit/task/init_spec.rb
@@ -1,0 +1,116 @@
+require_relative '../../../tasks/init'
+
+describe Reboot::Task do # rubocop:disable RSpec/FilePath
+  context 'on Windows' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('windows') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        command = 'shutdown.exe /r /t 3 /d p:4:1 '
+        reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout' do
+          command = 'shutdown.exe /r /t 20 /d p:4:1 '
+          reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+
+        it 'does not allow timeouts < 3' do
+          reboot = described_class.new('timeout' => 0)
+          command = 'shutdown.exe /r /t 3 /d p:4:1 '
+          reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        command = 'shutdown.exe /s /t 3 /d p:4:1 '
+        reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+    end
+  end
+
+  context 'on Solaris' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('SunOS') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        command = ['shutdown', '-y', '-i', '6', '-g', 0, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout' do
+          command = ['shutdown', '-y', '-i', '6', '-g', 20, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        command = ['shutdown', '-y', '-i', '5', '-g', 0, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+    end
+  end
+
+  context 'on Linux' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('Linux') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        command = ['shutdown', '-r', '+0', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout by rounding up' do
+          command = ['shutdown', '-r', '+1', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        command = ['shutdown', '-P', '+0', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+    end
+  end
+end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -9,6 +9,10 @@
     "message": {
       "description": "Shutdown message for systems that support it",
       "type": "Optional[Pattern[/^[^|&]*$/]]"
+    },
+    "shutdown_only": {
+      "description": "Only shut the machine down, do not reboot",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,74 +1,97 @@
 require 'facter'
 require 'json'
 
-params   = JSON.parse(STDIN.read)
-timeout  = params['timeout'].to_i || 3
-message  = params['message']
+class Reboot # rubocop:disable Style/ClassAndModuleChildren
+  # Class for rebooting the system. This doesn't need to be a class but it allows for automated testing
+  class Task
+    attr_accessor :timeout
 
-def async_command(cmd)
-  wait_time = 3
-  case Facter.value(:kernel)
-  when 'windows'
-    # This appears to be the only way to get the processes to properly detach
-    # themselves, it was a HUGE PAIN to fugure out
-    require 'win32/process'
-    Process.create(command_line: "cmd /c start #{cmd}",
-                   creation_flags: Process::DETACHED_PROCESS)
-  else
-    # Fork the process so that we can have one return the status and one
-    # actually do the work
-    if fork.nil?
-      # Detatch itself completely
-      Process.daemon
-      # Wait the prescribed amount of time
-      sleep wait_time
-      # Replace itself with the reboot command
-      exec(*cmd)
+    def initialize(opts = {})
+      @timeout       = opts['timeout'].to_i
+      @message       = opts['message']
+      @shutdown_only = opts['shutdown_only'] || false
+    end
+
+    def execute!
+      # Actually shut down the computer
+      if Facter.value(:kernel) == 'windows'
+        timeout = (@timeout < 3) ? 3 : @timeout
+        async_command(windows_shutdown_command(timeout: timeout, message: @message))
+      else
+        # Round to minutes for everything but SunOS
+        timeout = if Facter.value(:kernel) != 'SunOS'
+                    (@timeout / 60.0).ceil
+                  else
+                    @timeout
+                  end
+        async_command(unix_shutdown_command(timeout: timeout, message: @message))
+      end
+    end
+
+    def async_command(cmd)
+      wait_time = 3
+      case Facter.value(:kernel)
+      when 'windows'
+        # This appears to be the only way to get the processes to properly detach
+        # themselves, it was a HUGE PAIN to fugure out
+        require 'win32/process'
+        Process.create(
+          command_line: "cmd /c start #{cmd}",
+          creation_flags: Process::DETACHED_PROCESS,
+        )
+      else
+        # Fork the process so that we can have one return the status and one
+        # actually do the work
+        if fork.nil?
+          # Detatch itself completely
+          Process.daemon
+          # Wait the prescribed amount of time
+          sleep wait_time
+          # Replace itself with the reboot command
+          exec(*cmd)
+        end
+      end
+    end
+
+    def shutdown_executable_windows
+      if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
+        "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe"
+      elsif File.exist?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
+        "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe"
+      else
+        'shutdown.exe'
+      end
+    end
+
+    def windows_shutdown_command(params)
+      message_params   = ['/c', "\"#{params[:message]}\""] if params[:message]
+      reboot_param     = @shutdown_only ? '/s' : '/r'
+      [shutdown_executable_windows, reboot_param, '/t', params[:timeout], '/d', 'p:4:1', message_params].join(' ')
+    end
+
+    def unix_shutdown_command(params)
+      require 'shellwords'
+      escaped_message = Shellwords.escape(params[:message])
+      flags = if Facter.value(:kernel) == 'SunOS'
+                init_level = @shutdown_only ? '5' : '6'
+                ['-y', '-i', init_level, '-g', params[:timeout], escaped_message]
+              else
+                reboot_flag = @shutdown_only ? '-P' : '-r'
+                [reboot_flag, "+#{params[:timeout]}", escaped_message]
+              end
+      ['shutdown', flags, '</dev/null', '>/dev/null', '2>&1', '&'].flatten
     end
   end
 end
 
-def shutdown_executable_windows
-  if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
-    "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe"
-  elsif File.exist?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
-    "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe"
-  else
-    'shutdown.exe'
-  end
-end
+# Actually run the reboot if we got piped input
+unless STDIN.tty?
+  reboot = Reboot::Task.new(JSON.parse(STDIN.read))
+  reboot.execute!
 
-def windows_shutdown_command(params)
-  params[:timeout] = 3 if params[:timeout] < 3
-  message_params = ['/c', "\"#{params[:message]}\""] if params[:message]
-  [shutdown_executable_windows, '/r', '/t', params[:timeout], '/d', 'p:4:1', message_params].join(' ')
+  result = {
+    'status' => 'queued',
+    'timeout' => reboot.timeout,
+  }
+  JSON.dump(result, STDOUT)
 end
-
-def unix_shutdown_command(params)
-  require 'shellwords'
-  escaped_message = Shellwords.escape(params[:message])
-  flags = if Facter.value(:kernel) == 'SunOS'
-            ['-y', '-i', '6', '-g', params[:timeout], escaped_message]
-          else
-            ['-r', "+#{params[:timeout]}", escaped_message]
-          end
-  ['shutdown', flags, '</dev/null', '>/dev/null', '2>&1', '&'].flatten
-end
-
-# Actually shut down the computer
-if Facter.value(:kernel) == 'windows'
-  async_command(windows_shutdown_command(timeout: timeout, message: message))
-else
-  # Round to minutes for everything but SunOS
-  unless Facter.value(:kernel) == 'SunOS'
-    minutes = (timeout / 60.0).ceil
-    timeout = minutes
-  end
-  async_command(unix_shutdown_command(timeout: timeout, message: message))
-end
-
-result = {
-  'status' => 'queued',
-  'timeout' => timeout,
-}
-JSON.dump(result, STDOUT)


### PR DESCRIPTION
## Overview

Adds the `shutdown_only` parameter which allows shutting down of servers without a reboot (for decommissioning workflows, cloud etc.)

Also adds ✨ automated tests ✨ for the task 😮 
