### PR TITLE
(BOLT-955) Add bash and powershell implementations of reboot task

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,6 +1,7 @@
 {
   "description": "Reboots a machine",
   "supports_noop": false,
+  "input_method": "stdin",
   "parameters": {
     "timeout": {
       "description": "Timeout before shutdown (seconds)",
@@ -10,5 +11,10 @@
       "description": "Shutdown message for systems that support it",
       "type": "Optional[Pattern[/^[^|&]*$/]]"
     }
-  }
+  },
+  "implementations": [
+    { "name": "init.rb", "requirements": ["puppet-agent"] },
+    { "name": "nix.sh", "requirements": ["shell"], "input_method": "environment" },
+    { "name": "win.ps1", "requirements": ["powershell"], "input_method": "powershell" }
+  ]
 }

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -60,11 +60,13 @@ if Facter.value(:kernel) == 'windows'
   async_command(windows_shutdown_command(timeout: timeout, message: message))
 else
   # Round to minutes for everything but SunOS
-  unless Facter.value(:kernel) == 'SunOS'
-    minutes = (timeout / 60.0).ceil
-    timeout = minutes
+  if Facter.value(:kernel) == 'SunOS'
+    timeout_os = timeout
+  else
+    timeout_os = (timeout / 60.0).ceil
+    timeout = timeout_os * 60
   end
-  async_command(unix_shutdown_command(timeout: timeout, message: message))
+  async_command(unix_shutdown_command(timeout: timeout_os, message: message))
 end
 
 result = {

--- a/tasks/nix.json
+++ b/tasks/nix.json
@@ -1,0 +1,16 @@
+{
+  "description": "Reboots a machine",
+  "private": true,
+  "supports_noop": false,
+  "input_method": "environment",
+  "parameters": {
+    "timeout": {
+      "description": "Timeout before shutdown (seconds)",
+      "type": "Optional[Integer]"
+    },
+    "message": {
+      "description": "Shutdown message for systems that support it",
+      "type": "Optional[Pattern[/^[^|&]*$/]]"
+    }
+  }
+}

--- a/tasks/nix.sh
+++ b/tasks/nix.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -n "$PT_timeout" ]; then
+  timeout=$PT_timeout
+else
+  timeout=3
+fi
+
+if [ -n "$PT_message" ]; then
+  message=$PT_message
+fi
+
+if [[ `uname -s` == 'SunOS' ]]; then
+  shutdown -y -i 6 -g $timeout $message </dev/null >/dev/null 2>&1 &
+else
+  # Round to minutes
+  if [ $timeout -gt 0 ]; then
+    let timeout_min=($timeout+59)/60
+    let timeout=$timeout_min*60
+    shutdown -r +${timeout_min} $message </dev/null >/dev/null 2>&1 &
+  else
+    shutdown -r 0 $message </dev/null >/dev/null 2>&1 &
+  fi
+fi
+
+echo "{\"status\":\"queued\",\"timeout\":$timeout}"
+

--- a/tasks/win.json
+++ b/tasks/win.json
@@ -1,0 +1,15 @@
+{
+  "description": "Reboots a machine",
+  "private": true,
+  "supports_noop": false,
+  "parameters": {
+    "timeout": {
+      "description": "Timeout before shutdown (seconds)",
+      "type": "Optional[Integer]"
+    },
+    "message": {
+      "description": "Shutdown message for systems that support it",
+      "type": "Optional[Pattern[/^[^|&]*$/]]"
+    }
+  }
+}

--- a/tasks/win.ps1
+++ b/tasks/win.ps1
@@ -1,0 +1,22 @@
+[CmdletBinding()]
+Param(
+  [String]$message = "",
+  [Int]$timeout = 3
+)
+# If an error is encountered, the script will stop instead of the default of "Continue"
+$ErrorActionPreference = "Stop"
+
+If (Test-Path -Path $env:SYSTEMROOT\sysnative\shutdown.exe) {
+  $executable = "$env:SYSTEMROOT\sysnative\shutdown.exe"
+}
+ElseIf (Test-Path -Path $env:SYSTEMROOT\system32\shutdown.exe) {
+  $executable = "$env:SYSTEMROOT\system32\shutdown.exe"
+}
+Else {
+  $executable = "shutdown.exe"
+}
+
+cmd /c start $executable /r /t $timeout /d p:4:1 $message
+
+Write-Output "{""status"":""queued"",""timeout"":${timeout}}"
+


### PR DESCRIPTION
Add bash and powershell implementations of the reboot task so it can be run on systems without Ruby and Puppet installed.