### PR TITLE
(MODULES-8201) Add pending reboot due to domain join for windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The possible reasons for rebooting are:
 * pending_computer_rename: The computer needs to be renamed.
 * pending_dsc_reboot: DSC has requested a reboot.
 * pending_ccm_reboot: CCM has requested a reboot.
-
+* pending_domain_join: System has joined domain and is pending a reboot.
 
 ## Reference
 

--- a/lib/puppet/provider/reboot/windows.rb
+++ b/lib/puppet/provider/reboot/windows.rb
@@ -86,6 +86,7 @@ Puppet::Type.type(:reboot).provide :windows do
       :pending_computer_rename,
       :pending_dsc_reboot,
       :pending_ccm_reboot,
+      :pending_domain_join,
     ]
 
     if @resource[:onlyif] && @resource[:unless]
@@ -217,6 +218,13 @@ Puppet::Type.type(:reboot).provide :windows do
 
     Puppet.debug('Pending reboot: CCM ClientUtilities') if reboot
     reboot
+  end
+
+  def pending_domain_join?
+    path = 'SYSTEM\CurrentControlSet\Services\Netlogon\JoinDomain'
+    pending = key_exists?(path)
+    Puppet.debug("Pending reboot: HKLM\\#{path}") if pending
+    pending
   end
 
   private

--- a/lib/puppet/type/reboot.rb
+++ b/lib/puppet/type/reboot.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:reboot) do
     possible_values = [
       :reboot_required, :component_based_servicing, :windows_auto_update,
       :pending_file_rename_operations, :package_installer,
-      :pending_computer_rename, :pending_dsc_reboot, :pending_ccm_reboot
+      :pending_computer_rename, :pending_dsc_reboot, :pending_ccm_reboot, :pending_domain_join
     ]
 
     validate do |values|
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:reboot) do
     possible_values = [
       :reboot_required, :component_based_servicing, :windows_auto_update,
       :pending_file_rename_operations, :package_installer,
-      :pending_computer_rename, :pending_dsc_reboot, :pending_ccm_reboot
+      :pending_computer_rename, :pending_dsc_reboot, :pending_ccm_reboot, :pending_domain_join
     ]
 
     validate do |values|

--- a/spec/unit/provider/reboot/windows_spec.rb
+++ b/spec/unit/provider/reboot/windows_spec.rb
@@ -465,6 +465,22 @@ describe Puppet::Type.type(:reboot).provider(:windows) do
       end
     end
 
+    context 'Domain Join' do
+      let(:path) { 'SYSTEM\CurrentControlSet\Services\Netlogon\JoinDomain' }
+
+      it 'reboots if the JoinDomain key is present' do
+        expects_registry_key(path).yields(stub('reg'))
+
+        provider.should be_pending_domain_join
+      end
+
+      it 'ignores if the JoinDomain key is absent' do
+        expects_registry_key_not_found(path)
+
+        provider.should_not be_pending_domain_join
+      end
+    end
+
     context 'with reboot_required provider property' do
       it 'does not indicate a reboot by default' do
         expect(provider.reboot_required).to be_falsey
@@ -488,6 +504,7 @@ describe Puppet::Type.type(:reboot).provider(:windows) do
         provider.expects(:pending_computer_rename?).returns(false)
         provider.expects(:pending_dsc_reboot?).returns(false)
         provider.expects(:pending_ccm_reboot?).returns(false)
+        provider.expects(:pending_domain_join?).returns(false)
 
         expect(provider).not_to be_reboot_pending
       end
@@ -506,6 +523,7 @@ describe Puppet::Type.type(:reboot).provider(:windows) do
         # provider.expects(:pending_computer_rename?).returns(true)
         provider.expects(:pending_dsc_reboot?).returns(false)
         # provider.expects(:pending_ccm_reboot?).returns(true)
+        # provider.expects(:pending_domain_join?).returns(true)
 
         expect(provider).not_to be_reboot_pending
       end
@@ -524,6 +542,7 @@ describe Puppet::Type.type(:reboot).provider(:windows) do
         provider.expects(:pending_computer_rename?).returns(false)
         # provider.expects(:pending_dsc_reboot?).returns(true)
         provider.expects(:pending_ccm_reboot?).returns(false)
+        provider.expects(:pending_domain_join?).returns(false)
 
         expect(provider).not_to be_reboot_pending
       end


### PR DESCRIPTION
Add an option to the module that checks if there is a pending reboot due to a domain join.  This will allow flexibility when puppet is not only joining a server to the domain but also installing software that will trigger a reboot due to software installation.  This is especially useful when provisioning servers thru something like Cloudbolt and having a system reboot in the middle of a run will cause failures.