### PR TITLE
(BOLT-957) Make last_boot_time task more portable

### DIFF
--- a/tasks/last_boot_time.sh
+++ b/tasks/last_boot_time.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-if [ $(uname) = Darwin ]; then
-  last -1 reboot
-else
-  last -1 -F reboot
-fi
+
+# Try -F for time in seconds, fall back to without if unavailable
+last -1 -F reboot 2>/dev/null || last -1 reboot


### PR DESCRIPTION
Use the `-F` option for `last` when available to get a time with
seconds, but if it errors fallback to `last` without `-F`.

Fixes tests on EL 5 systems.