### PR TITLE
(maint) Add useful metadata for the reboot plan and last_boot_time tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ This can take a single reason or an array of reasons.
 
 See the [Reboot when certain conditions are met](#reboot-when-certain-conditions-are-met) section for reasons why you might reboot.
 
-### Plan: `reboot::wait`
+### Plan: `reboot`
 
-This plan is intended to be used as part of other [plans](https://puppet.com/docs/bolt/latest/writing_plans.html) and allows Bolt to wait for a server to reboot before continuing.
+This plan is intended to be used as part of other [plans](https://puppet.com/docs/bolt/latest/writing_plans.html) and allows Bolt to wait for a server to reboot before continuing. It requires Bolt 1.0+ and/or PE 2019.0+.
 
 Here is an example of using this module to reboot servers, wait for them to come back, then check the status of a service:
 

--- a/tasks/last_boot_time_nix.json
+++ b/tasks/last_boot_time_nix.json
@@ -1,3 +1,8 @@
 {
-  "description": "Gets the last boot time of a Linux system"
+  "description": "Gets the last boot time of a Linux system",
+  "private": true,
+  "supports_noop": false,
+  "input_method": "environment",
+  "parameters": {
+  }
 }

--- a/tasks/last_boot_time_win.json
+++ b/tasks/last_boot_time_win.json
@@ -1,3 +1,8 @@
 {
-  "description": "Gets the last boot time of a Windows system"
+  "description": "Gets the last boot time of a Windows system",
+  "private": true,
+  "supports_noop": false,
+  "input_method": "environment",
+  "parameters": {
+  }
 }


### PR DESCRIPTION
Add required versions of Bolt and PE for the reboot plan. Also make the extra implementations of last_boot_time private so that tools that support implementations and the private key only show a single task.