### PR TITLE
(MAINT) Fix hand crafting the gemfile.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -14,6 +14,12 @@ Gemfile:
       - gem: master_manipulator
       - gem: puppet-blacksmith
         version: '~> 3.4'
+      - gem: bolt
+        version: '~> 1.3'
+        condition: ENV['GEM_BOLT']
+      - gem: beaker-task_helper
+        version: '~> 1.5'
+        condition: ENV['GEM_BOLT']
 
 appveyor.yml:
   matrix_extras:


### PR DESCRIPTION
This change should mean that the next time pdk update is run the `if`
block that loads the `bolt` and `beaker-task_helper` into `if`
conditionals on their own lines. This way the `if` block doesn't have
to be added to the Gemfile by hand after each update.