### PR TITLE
{WIP} (MODULES-8456) Add rake task for testing module tasks with bolt

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -39,3 +39,7 @@ appveyor.yml:
 
 spec/default_facts.yml:
   unmanaged: true
+
+Rakefile:
+  extras:
+    - 'task :task_acceptance => [:spec_prep, :beaker]'

--- a/Rakefile
+++ b/Rakefile
@@ -76,3 +76,4 @@ EOM
   end
 end
 
+task :task_acceptance => [:spec_prep, :beaker]


### PR DESCRIPTION
A pattern for using bolt to test modules with task content is taking shape in the modules-unified testing infra. Imporant details include optionally requiring the bolt gem using the GEM_BOLT environment variable in order to only require bolt when a suitable puppet version (~> 6) is available. Another important detail is that acceptance tests are invoked using a rake task called `task_acceptance`. This commit adds a rake task that invokes `spec_prep` and `beaker`.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-reboot/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12016&summary=%5BREBOOT%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
