### PR TITLE
(BOLT-1057) Pass required args to run_task

### DIFF
--- a/spec/acceptance/tasks/init_spec.rb
+++ b/spec/acceptance/tasks/init_spec.rb
@@ -22,7 +22,7 @@ describe 'reboot task', bolt: true do
   let(:tm) { 60 }
 
   it 'reports the last boot time' do
-    results = run_task('reboot::last_boot_time', 'agent', config: config, inventory: inventory)
+    results = run_task('reboot::last_boot_time', 'agent', {}, config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['_output']).to be


### PR DESCRIPTION
Previously, the tests were omitting the `params` argument to `run_task`.
In newer versions of BoltSpec, that parameter is going to be required,
so now we always pass it.