### PR TITLE
(MODULES-8717) Fix dependency issue on boltspec

### DIFF
--- a/spec/acceptance/tasks/init_spec.rb
+++ b/spec/acceptance/tasks/init_spec.rb
@@ -1,6 +1,4 @@
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 require 'time'
 
 describe 'reboot task', bolt: true do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 require 'beaker-pe'
 require 'beaker-puppet'
 require 'beaker-rspec'


### PR DESCRIPTION
Moving the requires causing dependancy issues to the spec_helper_acceptance so they don't conflict with each other.