### PR TITLE
MODULES-8726: Ensure sbin is in the path

### DIFF
--- a/tasks/nix.sh
+++ b/tasks/nix.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export PATH=$PATH:/usr/sbin:/sbin
 set -e
 
 if [ -n "$PT_timeout" ]; then


### PR DESCRIPTION
The shutdown command is usually in /sbin or /usr/sbin.  Many normal
users don't already have them in their path.

Running bolt task run reboot -n somenode --run-as root doesn't reboot
the server, but does return a success.

Add /usr/sbin and /sbin to the path in the nix.sh script

