### PR TITLE
Handle an empty $nodes argument cleanly

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -16,6 +16,9 @@ plan reboot (
 ) {
   $targets = get_targets($nodes)
 
+  # Short-circuit the plan if the TargetSpec given was empty
+  if $targets.empty { return ResultSet.new([]) }
+
   # Get last boot time
   $begin_boot_time_results = without_default_logging() || {
     run_task('reboot::last_boot_time', $targets)

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -70,4 +70,9 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     result = run_plan('reboot', 'nodes' => 'foo,bar')
     expect(result).not_to be_ok
   end
+
+  it 'does not error when given an empty TargetSpec $nodes' do
+    result = run_plan('reboot', 'nodes' => [])
+    expect(result).to be_ok
+  end
 end


### PR DESCRIPTION
Prior to this commit the reboot plan raised an error calling max()
without a valid argument. This commit causes the plan to short-circuit
and return an empty ResultSet in the event an empty TargetSpec was given
as the $nodes argument.

Long-term, the plan should probably be modified to always return a
meaningful and clearly defined result on completion.