### PR TITLE
Fix plan return value

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -6,6 +6,7 @@
 # @param disconnect_wait How long (in seconds) to wait before checking whether the server has rebooted. Defaults to 10.
 # @param reconnect_timeout How long (in seconds) to attempt to reconnect before giving up. Defaults to 180.
 # @param retry_interval How long (in seconds) to wait between retries. Defaults to 1.
+# @param fail_plan_on_errors Raise an error if any targets do not successfully reboot. Defaults to true.
 plan reboot (
   TargetSpec $nodes,
   Optional[String] $message = undef,
@@ -13,6 +14,7 @@ plan reboot (
   Integer[0] $disconnect_wait = 10,
   Integer[0] $reconnect_timeout = 180,
   Integer[0] $retry_interval = 1,
+  Boolean    $fail_plan_on_errors = true,
 ) {
   $targets = get_targets($nodes)
 
@@ -113,7 +115,7 @@ plan reboot (
 
   $result_set = ResultSet.new($ok_set + $error_set)
 
-  if !$result_set.error_set.empty() {
+  if ($fail_plan_on_errors and !$result_set.ok) {
     fail_plan('One or more targets failed to reboot', 'reboot/error', {
       action     => 'plan/reboot',
       result_set => $result_set,

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -16,6 +16,9 @@ plan reboot (
 ) {
   $targets = get_targets($nodes)
 
+  # Short-circuit the plan if the TargetSpec given was empty
+  if $targets.empty { return ResultSet.new([]) }
+
   # Get last boot time
   $begin_boot_time_results = without_default_logging() || {
     run_task('reboot::last_boot_time', $targets)

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -20,7 +20,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to eq(nil)
+    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
   end
 
   it 'reboots a target that takes awhile to reboot' do
@@ -34,7 +34,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to eq(nil)
+    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
   end
 
   it 'waits until all targets have rebooted' do
@@ -47,7 +47,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to eq(nil)
+    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
   end
 
   it 'accepts extra arguments' do
@@ -62,7 +62,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'reboot_delay' => 5, 'message' => 'restarting',
                                 'disconnect_wait' => 1, 'reconnect_timeout' => 30, 'retry_interval' => 5)
-    expect(result.value).to eq(nil)
+    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
   end
 
   it 'errors if last_boot_time is unavailable' do

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -70,4 +70,9 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     result = run_plan('reboot', 'nodes' => 'foo,bar')
     expect(result).not_to be_ok
   end
+
+  it 'does not error when given an empty TargetSpec $nodes' do
+    result = run_plan('reboot', 'nodes' => [])
+    expect(result).to be_ok
+  end
 end

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -20,7 +20,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
+    expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
   end
 
   it 'reboots a target that takes awhile to reboot' do
@@ -34,7 +34,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
+    expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
   end
 
   it 'waits until all targets have rebooted' do
@@ -47,7 +47,33 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'disconnect_wait' => 0)
-    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
+    expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
+      expect(result.value.ok_set.size).to eql(2)
+  end
+
+  context 'when reconnect_timeout is exceeded' do
+    it 'fails plan on fail_plan_on_errors==true' do
+      start_time = Time.now - 1
+      expect_task('reboot::last_boot_time').return do |targets:, **|
+        Bolt::ResultSet.new(targets.map { |targ| Bolt::Result.new(targ, message: start_time) })
+      end
+      expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
+
+      result = run_plan('reboot', 'nodes' => 'foo,bar','disconnect_wait' => 0, 'reconnect_timeout' => 0)
+      expect(result.value).to be_a(Bolt::PlanFailure)
+    end
+
+    it 'returns ResultSet on fail_plan_on_errors==false' do
+      start_time = Time.now - 1
+      expect_task('reboot::last_boot_time').return do |targets:, **|
+        Bolt::ResultSet.new(targets.map { |targ| Bolt::Result.new(targ, message: start_time) })
+      end
+      expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
+
+      result = run_plan('reboot', 'nodes' => 'foo,bar','disconnect_wait' => 0, 'reconnect_timeout' => 0, 'fail_plan_on_errors' => false)
+      expect(result.value).to be_a(Bolt::ResultSet)
+      expect(result.value.error_set.size).to eql(2)
+    end
   end
 
   it 'accepts extra arguments' do
@@ -62,7 +88,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
 
     result = run_plan('reboot', 'nodes' => 'foo,bar', 'reboot_delay' => 5, 'message' => 'restarting',
                                 'disconnect_wait' => 1, 'reconnect_timeout' => 30, 'retry_interval' => 5)
-    expect(result.value).to be_a(Bolt::ResultSet).and satisfy { |rs| rs.ok }
+    expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
   end
 
   it 'errors if last_boot_time is unavailable' do


### PR DESCRIPTION
Assuming some nodes successfully reboot and some nodes don't, when the
reboot plan is invoked with `_catch_errors => true`, it should return
meaningful data so that the end user can decide how to handle or report
on which nodes failed to reboot while potentially continuing forward
to another task with the set of nodes that succeeded.

This commit makes the reboot plan always return meaningful data, even
when erroring.