### PR TITLE
Add additional guards for nix process detach

### DIFF
--- a/tasks/nix.sh
+++ b/tasks/nix.sh
@@ -30,7 +30,12 @@ else
   timeout_min=$(($timeout/60))
   timeout_sec=$(($timeout%60))
   nohup bash -c "sleep $timeout_sec; shutdown -r +$timeout_min $message" </dev/null >/dev/null 2>&1 &
+  disown
 fi
 
-echo "{\"status\":\"queued\",\"timeout\":$timeout}"
+# There are some weird race conditions that might make detached jobs still die
+# when this shell exits. The sync (which otherwise shouldn't do much) seems to
+# eliminate them.
+sync
 
+echo "{\"status\":\"queued\",\"timeout\":$timeout}"


### PR DESCRIPTION
Observing some weird race-condition-y behaviors where the nix.sh script
previously was not reliable in rebooting systems. Most of the time with
an attached TTY, the subprocess was still being killed when the
TTY-attached parent shell terminated.

Adding a `sync` call seems to work around the problem.

Adding an explicit `disown` for linux just for completeness. It was not
shown to help with the observed race condition, which is resoseems to
work around the problem.

Adding an explicit `disown` for linux just for completeness. It was not
shown to help with the observed race condition (which is resolved by
`sync`). `disown` is a bash built-in, and this is a bash script so we
should be fine to use it.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-reboot/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12016&summary=%5BREBOOT%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
