### PR TITLE
Add `shutdown_only` parameter to tasks

### DIFF
--- a/spec/unit/task/init_spec.rb
+++ b/spec/unit/task/init_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require_relative '../../../tasks/init'
+
+describe Reboot::Task do # rubocop:disable RSpec/FilePath
+  context 'on Windows' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('windows') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        command = 'shutdown.exe /r /t 3 /d p:4:1 '
+        reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout' do
+          command = 'shutdown.exe /r /t 20 /d p:4:1 '
+          reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+
+        it 'does not allow timeouts < 3' do
+          reboot = described_class.new('timeout' => 0)
+          command = 'shutdown.exe /r /t 3 /d p:4:1 '
+          reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+  end
+
+  context 'on Solaris' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('SunOS') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        # Enforces minimum 3s timeout.
+        command = ['shutdown', '-y', '-i', '6', '-g', 3, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout' do
+          command = ['shutdown', '-y', '-i', '6', '-g', 20, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+          reboot.expects(:async_command).with(command).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+  end
+
+  context 'on Linux' do
+    before(:each) { Facter.stubs(:value).with(:kernel).returns('Linux') }
+
+    context 'when rebooting' do
+      let(:reboot) { described_class.new }
+
+      it 'runs the correct command' do
+        command = ['shutdown', '-r', 'now', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command, 3).returns(nil)
+        reboot.execute!
+      end
+
+      context 'with a small timeout' do
+        let(:reboot) { described_class.new('timeout' => 20) }
+
+        it 'handles the timeout by sleeping' do
+          command = ['shutdown', '-r', 'now', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+          reboot.expects(:async_command).with(command, 20).returns(nil)
+          reboot.execute!
+        end
+      end
+
+      context 'with a large timeout' do
+        let(:reboot) { described_class.new('timeout' => 90) }
+
+        it 'handles the timeout by sleeping' do
+          command = ['shutdown', '-r', '+1', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+          reboot.expects(:async_command).with(command, 30).returns(nil)
+          reboot.execute!
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/task/init_spec.rb
+++ b/spec/unit/task/init_spec.rb
@@ -34,6 +34,17 @@ describe Reboot::Task do # rubocop:disable RSpec/FilePath
         end
       end
     end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        command = 'shutdown.exe /s /t 3 /d p:4:1 '
+        reboot.expects(:shutdown_executable_windows).returns('shutdown.exe')
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+    end
   end
 
   context 'on Solaris' do
@@ -59,6 +70,17 @@ describe Reboot::Task do # rubocop:disable RSpec/FilePath
         end
       end
     end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        # Enforces minimum 3s timeout.
+        command = ['shutdown', '-y', '-i', '5', '-g', 3, "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command).returns(nil)
+        reboot.execute!
+      end
+    end
   end
 
   context 'on Linux' do
@@ -69,6 +91,7 @@ describe Reboot::Task do # rubocop:disable RSpec/FilePath
 
       it 'runs the correct command' do
         command = ['shutdown', '-r', 'now', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        # Enforces minimum 3s timeout.
         reboot.expects(:async_command).with(command, 3).returns(nil)
         reboot.execute!
       end
@@ -91,6 +114,17 @@ describe Reboot::Task do # rubocop:disable RSpec/FilePath
           reboot.expects(:async_command).with(command, 30).returns(nil)
           reboot.execute!
         end
+      end
+    end
+
+    context 'when shutting down' do
+      let(:reboot) { described_class.new('shutdown_only' => true) }
+
+      it 'runs the correct command' do
+        # Enforces minimum 3s timeout.
+        command = ['shutdown', '-P', 'now', "''", '</dev/null', '>/dev/null', '2>&1', '&']
+        reboot.expects(:async_command).with(command, 3).returns(nil)
+        reboot.execute!
       end
     end
   end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -10,6 +10,10 @@
     "message": {
       "description": "Shutdown message for systems that support it",
       "type": "Optional[Pattern[/^[^|&]*$/]]"
+    },
+    "shutdown_only": {
+      "description": "Only shut the machine down, do not reboot",
+      "type": "Optional[Boolean]"
     }
   },
   "implementations": [

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -2,76 +2,95 @@
 require 'facter'
 require 'json'
 
-params   = JSON.parse(STDIN.read)
-timeout  = params['timeout'].to_i || 3
-message  = params['message']
+class Reboot # rubocop:disable Style/ClassAndModuleChildren
+  # Class for rebooting the system. This doesn't need to be a class but it allows for automated testing
+  class Task
+    attr_accessor :timeout
 
-# Force a minimum timeout of 3 seconds to allow the task response to be delivered.
-timeout = 3 if timeout < 3
+    def initialize(opts = {})
+      @timeout       = opts['timeout'].to_i
+      @message       = opts['message']
 
-def async_command(cmd, wait_time = nil)
-  case Facter.value(:kernel)
-  when 'windows'
-    # This appears to be the only way to get the processes to properly detach
-    # themselves, it was a HUGE PAIN to fugure out
-    require 'win32/process'
-    Process.create(command_line: "cmd /c start #{cmd}",
-                   creation_flags: Process::DETACHED_PROCESS)
-  else
-    # Fork the process so that we can have one return the status and one
-    # actually do the work
-    if fork.nil?
-      # Detatch itself completely
-      Process.daemon
-      # Wait the prescribed amount of time
-      sleep wait_time if wait_time
-      # Replace itself with the reboot command
-      exec(*cmd)
+      # Force a minimum timeout of 3 seconds to allow the task response to be delivered.
+      @timeout = 3 if @timeout < 3
+    end
+
+    def execute!
+      # Actually shut down the computer
+      case Facter.value(:kernel)
+      when 'windows'
+        async_command(windows_shutdown_command(timeout: @timeout, message: @message))
+      when 'SunOS'
+        async_command(unix_shutdown_command(timeout: @timeout, message: @message))
+      else
+        # Specify timeout in minutes, or now. Let the forked process sleep to handle seconds.
+        timeout_min = @timeout / 60
+        timeout_min = (timeout_min > 0) ? "+#{timeout_min}" : 'now'
+        timeout_sec = timeout % 60
+        async_command(unix_shutdown_command(timeout: timeout_min, message: @message), timeout_sec)
+      end
+    end
+
+    def async_command(cmd, wait_time = nil)
+      case Facter.value(:kernel)
+      when 'windows'
+        # This appears to be the only way to get the processes to properly detach
+        # themselves, it was a HUGE PAIN to fugure out
+        require 'win32/process'
+        Process.create(
+          command_line: "cmd /c start #{cmd}",
+          creation_flags: Process::DETACHED_PROCESS,
+        )
+      else
+        # Fork the process so that we can have one return the status and one
+        # actually do the work
+        if fork.nil?
+          # Detatch itself completely
+          Process.daemon
+          # Wait the prescribed amount of time
+          sleep wait_time if wait_time
+          # Replace itself with the reboot command
+          exec(*cmd)
+        end
+      end
+    end
+
+    def shutdown_executable_windows
+      if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
+        "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe"
+      elsif File.exist?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
+        "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe"
+      else
+        'shutdown.exe'
+      end
+    end
+
+    def windows_shutdown_command(params)
+      message_params   = ['/c', "\"#{params[:message]}\""] if params[:message]
+      [shutdown_executable_windows, '/r', '/t', params[:timeout], '/d', 'p:4:1', message_params].join(' ')
+    end
+
+    def unix_shutdown_command(params)
+      require 'shellwords'
+      escaped_message = Shellwords.escape(params[:message])
+      flags = if Facter.value(:kernel) == 'SunOS'
+                ['-y', '-i', '6', '-g', params[:timeout], escaped_message]
+              else
+                ['-r', params[:timeout], escaped_message]
+              end
+      ['shutdown', flags, '</dev/null', '>/dev/null', '2>&1', '&'].flatten
     end
   end
 end
 
-def shutdown_executable_windows
-  if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe")
-    "#{ENV['SYSTEMROOT']}\\sysnative\\shutdown.exe"
-  elsif File.exist?("#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe")
-    "#{ENV['SYSTEMROOT']}\\system32\\shutdown.exe"
-  else
-    'shutdown.exe'
-  end
-end
+# Actually run the reboot if we got piped input
+unless STDIN.tty?
+  reboot = Reboot::Task.new(JSON.parse(STDIN.read))
+  reboot.execute!
 
-def windows_shutdown_command(params)
-  message_params = ['/c', "\"#{params[:message]}\""] if params[:message]
-  [shutdown_executable_windows, '/r', '/t', params[:timeout], '/d', 'p:4:1', message_params].join(' ')
+  result = {
+    'status' => 'queued',
+    'timeout' => reboot.timeout,
+  }
+  JSON.dump(result, STDOUT)
 end
-
-def unix_shutdown_command(params)
-  require 'shellwords'
-  escaped_message = Shellwords.escape(params[:message])
-  flags = if Facter.value(:kernel) == 'SunOS'
-            ['-y', '-i', '6', '-g', params[:timeout], escaped_message]
-          else
-            ['-r', params[:timeout], escaped_message]
-          end
-  ['shutdown', flags, '</dev/null', '>/dev/null', '2>&1', '&'].flatten
-end
-
-# Actually shut down the computer
-if Facter.value(:kernel) == 'windows'
-  async_command(windows_shutdown_command(timeout: timeout, message: message))
-elsif Facter.value(:kernel) == 'SunOS'
-  async_command(unix_shutdown_command(timeout: timeout, message: message))
-else
-  # Specify timeout in minutes, or now. Let the forked process sleep to handle seconds.
-  timeout_min = timeout / 60
-  timeout_min = (timeout_min > 0) ? "+#{timeout_min}" : 'now'
-  timeout_sec = timeout % 60
-  async_command(unix_shutdown_command(timeout: timeout_min, message: message), timeout_sec)
-end
-
-result = {
-  'status' => 'queued',
-  'timeout' => timeout,
-}
-JSON.dump(result, STDOUT)

--- a/tasks/nix.json
+++ b/tasks/nix.json
@@ -11,6 +11,10 @@
     "message": {
       "description": "Shutdown message for systems that support it",
       "type": "Optional[Pattern[/^[^|&]*$/]]"
+    },
+    "shutdown_only": {
+      "description": "Only shut the machine down, do not reboot",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/win.json
+++ b/tasks/win.json
@@ -10,6 +10,10 @@
     "message": {
       "description": "Shutdown message for systems that support it",
       "type": "Optional[Pattern[/^[^|&]*$/]]"
+    },
+    "shutdown_only": {
+      "description": "Only shut the machine down, do not reboot",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/win.ps1
+++ b/tasks/win.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 Param(
   [String]$message = "",
-  [Int]$timeout = 3
+  [Int]$timeout = 3,
+  [Boolean]$shutdown_only = $false
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -21,13 +22,16 @@ If ($timeout -lt 3) {
   $timeout = 3
 }
 
+$reboot_param = "/r"
+If ($shutdown_only) {
+  $reboot_param = "/s"
+}
+
 If ($message -ne "") {
-  & $executable /r /t $timeout /d p:4:1 /c $message
+  & $executable $reboot_param /t $timeout /d p:4:1 /c $message
 }
 Else {
-  & $executable /r /t $timeout /d p:4:1
+  & $executable $reboot_param /t $timeout /d p:4:1
 }
 
-
 Write-Output "{""status"":""queued"",""timeout"":${timeout}}"
-


### PR DESCRIPTION
Adds the `shutdown_only` parameter which allows shutting down of servers without a reboot (for decommissioning workflows, cloud etc).

Adds ✨ automated unit tests ✨ for the task 😮