### PR TITLE
(maint) Prefer out::message to notice

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -46,7 +46,7 @@ plan reboot (
       }
 
       $plural = if $memo['pending'].size() > 1 { 's' }
-      notice("Waiting: ${$memo['pending'].size()} target${plural} rebooting")
+      out::message("Waiting: ${$memo['pending'].size()} target${plural} rebooting")
       $current_boot_time_results = run_task('reboot::last_boot_time', $memo['pending'], _catch_errors => true)
 
       # Compare boot times

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -18,6 +18,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
       Bolt::ResultSet.new(targets.map { |target| Bolt::Result.new(target, message: next_time.to_s) })
     }.be_called_times(2)
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
+    allow_any_out_message
 
     result = run_plan('reboot', 'targets' => 'foo,bar', 'disconnect_wait' => 0)
     expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
@@ -32,6 +33,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
       Bolt::ResultSet.new(targets.map { |target| Bolt::Result.new(target, message: next_time.to_s) })
     }.be_called_times(3)
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
+    allow_any_out_message
 
     result = run_plan('reboot', 'targets' => 'foo,bar', 'disconnect_wait' => 0)
     expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
@@ -45,6 +47,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
       Bolt::ResultSet.new(targets.zip(time_seq.shift).map { |targ, time| Bolt::Result.new(targ, message: time.to_s) })
     }.be_called_times(3)
     expect_task('reboot').always_return('status' => 'queued', 'timeout' => 0)
+    allow_any_out_message
 
     result = run_plan('reboot', 'targets' => 'foo,bar', 'disconnect_wait' => 0)
     expect(result.value).to be_ok.and be_a(Bolt::ResultSet)
@@ -85,6 +88,7 @@ describe 'reboot plan', :if => should_run_tests?, bolt: true do
     expect_task('reboot')
       .with_params('timeout' => 5, 'message' => 'restarting')
       .always_return('status' => 'queued', 'timeout' => 0)
+    allow_any_out_message
 
     result = run_plan('reboot', 'targets' => 'foo,bar', 'reboot_delay' => 5, 'message' => 'restarting',
                                 'disconnect_wait' => 1, 'reconnect_timeout' => 30, 'retry_interval' => 5)


### PR DESCRIPTION
Given the default log level for bolt will not surface this and the fact that out::message will be surfaced in the PE console when running plans in PE (no puppet log functions go to console, just to orchestration-services.log) prefer out::message to notice.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-reboot/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12016&summary=%5BREBOOT%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
