### PR TITLE
(MODULES-10955) More robust handling of reboot-task output

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -27,11 +27,10 @@ plan reboot (
   }
 
   # Reboot; catch errors here because the connection may get cut out from underneath
-  $reboot_result = run_task('reboot', $targets, timeout => $reboot_delay, message => $message)
+  run_task('reboot', $targets, timeout => $reboot_delay, message => $message)
 
-  # Wait long enough for all targets to trigger reboot, plus disconnect_wait to allow for shutdown time.
-  $timeouts = $reboot_result.map |$result| { $result['timeout'] }
-  $wait = max($timeouts)
+  # Use $reboot_delay as wait time, but at least 3s
+  $wait = max(3, $reboot_delay)
   reboot::sleep($wait+$disconnect_wait)
 
   $start_time = Timestamp()


### PR DESCRIPTION
The reboot task (that gets run in line 30) always returns the status and timeout. The timeout is (per definition) the max between 3 and $reboot_delay. No real dynamic output that is generated by the reboot task is used in the plan.

Hence: We can default to a $wait for the maximum of 3 or $reboot_delay. This way it does not matter to the plan what the reboot task runs. So broadcast-messages (and possibly other things) do not interfere with the parsing of the timeout.