### PR TITLE
(MODULES-10963) remove win32-process on Puppet 7

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -39,7 +39,12 @@ class Reboot # rubocop:disable Style/ClassAndModuleChildren
       when 'windows'
         # This appears to be the only way to get the processes to properly detach
         # themselves, it was a HUGE PAIN to fugure out
-        require 'win32/process'
+        # win32/process is needed on Puppet < 7
+        # Puppet 7 monkey patches Ruby's Process Module
+        # and Process.create will be available
+        require 'puppet'
+        require 'win32/process' if Puppet::Util::Package.versioncmp(Puppet.version, '7.0.0') < 0
+
         Process.create(
           command_line: "cmd /c start #{cmd}",
           creation_flags: Process::DETACHED_PROCESS,


### PR DESCRIPTION
Puppet 7 dropped the dependency on win32-process gem
in favour of monkey patching the Process Module.

As a repercussion, require `win32/process` will no
longer work on Puppet >= 7.0.0.

This commit updates the reboot task to only require
that specific gem if Puppet < 7.0.0

Enabled and run the test that were filtered out:
```
# without the fix:
Finished in 12 minutes 49 seconds (files took 2.06 seconds to load)
14 examples, 2 failures

Failed examples:

rspec ./spec/acceptance/tasks/init_spec.rb:17 # reboot task reboots a target
rspec ./spec/acceptance/tasks/init_spec.rb:24 # reboot task accepts a message


# with the fix
Finished in 11 minutes 33 seconds (files took 2.01 seconds to load)
14 examples, 0 failures
```

Tested manually on PE 2021.0.0 and the reboot task and plan can be run successfully


