### PR TITLE
(MODULES-11149) Modify result of 'last' to remove current time

### DIFF
--- a/tasks/last_boot_time_nix.sh
+++ b/tasks/last_boot_time_nix.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Try -F for time in seconds, fall back to without if unavailable
-last -1 -F reboot 2>/dev/null || last -1 reboot
+(last -1 -F reboot 2>/dev/null || last -1 reboot) | sed 's/\s-\s.*$//'


### PR DESCRIPTION
When doing 'last -1 reboot', the end of this line will show the current time on some platforms, since it shows both the start and end time of the session. Since the plan is simply comparing the raw string to see if we've rebooted, this makes it think we've always rebooted, since the end of this string changes every second. This commit slices off the end time, leaving only the login time.