### PR TITLE
pdksync - (GH-iac-334) Remove Support for Ubuntu 14.04/16.04

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   symlinks:
     reboot: "#{source_dir}"
   repositories:
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -72,8 +72,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
+        "14.04"
       ]
     },
     {


### PR DESCRIPTION
(GH-iac-334) Remove Support for Ubuntu 16.04
pdk version: `2.1.0` 
