### PR TITLE
pdksync - (GH-cat-11) Certify Support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
(GH-cat-11) Certify Support for Ubuntu 22.04
pdk version: `2.3.0` 
