### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,9 +89,14 @@ RSpec/ExpectInHook:
     - 'spec/unit/provider/reboot/posix_spec.rb'
 
 # Offense count: 1
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/unit/task/init_spec.rb'
+
+# Offense count: 1
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathSuffix:
   Exclude:
     - 'spec/acceptance/reboot_message.spec.rb'
 

--- a/spec/unit/task/init_spec.rb
+++ b/spec/unit/task/init_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 # require_relative '../../../tasks/init'
 require "#{File.dirname(__FILE__)}/../../../tasks/init.rb"
 
-describe Reboot::Task do # rubocop:disable RSpec/FilePath
+describe Reboot::Task do
   context 'on Windows' do
     before(:each) do
       allow(Facter).to receive(:value).with(:kernel).and_return('windows')


### PR DESCRIPTION
## Summary
Fixing CI failure due to rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Split RSpec/FilePath into RSpec/SpecFilePathSuffix and RSpec/SpecFilePathFormat. RSpec/FilePath cop is enabled by default, the two new cops are pending and need to be enabled explicitly. (@ydah)
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)